### PR TITLE
Small useful enhancements

### DIFF
--- a/sts-viewer/fallback.xsl
+++ b/sts-viewer/fallback.xsl
@@ -7,9 +7,13 @@
     version="1.0">
 
     <xsl:template match="/*">
-        <div class="fail">
-            <p>Fail: can't process a <code><xsl:value-of select="local-name()"/></code> document ... this tool handles (only) STS <code>standard</code>.</p>
+        <xsl:if test="not(self::standard)">
+            
+        <div class="warn">
+            <p>Warning: seeing a document named <code><xsl:value-of  select="local-name(.)"/></code> ... this tool is designed and tested for STS <code>standard</code> documents (in no namespace).</p>
         </div>
+        </xsl:if>
+        <xsl:apply-templates/>
     </xsl:template>
     
     <!--without a better rule, make a div -->

--- a/sts-viewer/index.html
+++ b/sts-viewer/index.html
@@ -48,6 +48,15 @@
       return spliceIntoPage(targetID, resultDocument, true);
     }
     
+    function loadGraphic(file,graphicID,expectedName) {
+       // const fr = new FileReader();
+       const anURL = URL.createObjectURL(file)
+       const expect = expectedName.split('/').pop().split('#')[0].split('?')[0];
+       const labelClass = ( file.name === expect ? 'aligned' : 'unknown' );
+       document.getElementById('label_'+graphicID).classList.add(labelClass);
+       document.getElementById(graphicID).src = anURL;
+     }
+
     const viewSection = eID => {
       let who = document.getElementById(eID); 
       let openers = getAncestorDetails(who);

--- a/sts-viewer/readme.md
+++ b/sts-viewer/readme.md
@@ -85,11 +85,3 @@ Other XSLT modules (`fallback.xsl` and `sts-tags-and-names.xsl`) only need to be
 For license information see the [repository readme](../README.md). (Public domain: reuse encouraged with credits.)
 
 The lead developer of this project is Wendell Piez, w e n d e l l (dot) p i e z (at) n i s t (dot) g o v (NIST/ITL/CSD, Secure Systems and Applications Group).
-
-## Tasks
-
-- [ ] test XSLTs under XSLT 3.0
-- [ ] set up sample suite?
-- [ ] document other application scenarios
-- [ ] formal 508 checking (with notes)
-- [ ] 'print-media' CSS

--- a/sts-viewer/sts-html.css
+++ b/sts-viewer/sts-html.css
@@ -15,6 +15,9 @@ p { margin: 0.6em 0em; max-width: 54em; line-height: 1.62 }
 #displaySTS > section.sts_standard { display: block; background-color: lemonchiffon; padding: 1vw; border: medium inset black;
   font-family: "Merriweather Web", Georgia,Cambria,"Times New Roman",Times,serif }
 
+#displaySTS > article.sts_article { display: block; background-color: whitesmoke; padding: 1vw; border: medium inset black;
+  font-family: "Merriweather Web", Georgia,Cambria,"Times New Roman",Times,serif }
+
 h1, h2, h3, h4, h5, h6, summary, .reflect, *:before { font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; }
 
 aside > *:last-child { margin-bottom: 0em }
@@ -58,7 +61,7 @@ aside > *:last-child { margin-bottom: 0em }
 #displaySTS div.boxed.labeled { border: none }
 
 #displaySTS div.sts_boxed-text,
-#displaySTS figure.sts_fig         { margin: 0.2em 0em; width: fit-content; padding: 0.8rem; outline: medium outset darkgrey }
+#displaySTS figure.sts_fig         { margin: 0.2em 0em; padding: 0.8rem; outline: medium outset darkgrey }
 
 #displaySTS figure.sts_fig *:first-child { margin-top: 0em }
 #displaySTS figure.sts_fig *:last-child  { margin-bottom: 0em }
@@ -179,6 +182,13 @@ table.control-matrix .control-title { width: 60% }
 
 #displaySTS div.fail { color: darkred; background-color: orange; padding: 0.4em }
 .fail code { font-weight: bold; font-size: 110% }
+
+#displaySTS div.warn { color: midnightblue; background-color: lemonchiffon; padding: 0.4em }
+.warn code { font-weight: bold; font-size: 110% }
+
+.graphicBox label { margin-right: 1em; padding: 0.4em }
+.aligned { display: none }
+.unknown  { color: darkred; background-color: pink }
 
 /* prevent sub and sup from shifting the line leading */
 sup, sub {

--- a/sts-viewer/sts-view10.xsl
+++ b/sts-viewer/sts-view10.xsl
@@ -107,6 +107,25 @@
         </section>
     </xsl:template>
     
+<!--    shim for JATS -->
+    <xsl:template match="article">
+        <article>
+            <xsl:apply-templates select="@*"/>            
+            <xsl:call-template name="add.class"/>
+            <xsl:apply-templates select="." mode="page.head"/>
+            <xsl:apply-templates/>
+        </article>
+    </xsl:template>
+    
+    <xsl:template match="article" mode="page.head">
+        <header>
+            <xsl:for-each select="child::front/*/title-group/article-title">
+                <h1>
+                    <xsl:apply-templates mode="page.head"/>
+                </h1>
+            </xsl:for-each>
+        </header>
+    </xsl:template>
     
     <xsl:template match="standard" mode="page.head">
         <header>
@@ -374,12 +393,20 @@
     </xsl:template>
     
     <xsl:template match="graphic">
-        <p>
-            <span class="reflect">
-            <xsl:text>graphic</xsl:text>
-            <xsl:apply-templates select="@*"/>
-            </span>
-        </p>
+        <xsl:variable name="imgID" select="concat('grphc-',generate-id(.))"/>
+        <div class="graphicBox">
+            <p>
+                <form>
+                    <label for="load_{$imgID}" class="img_label" id="label_{$imgID}">
+                        <xsl:text>Load file </xsl:text>
+                        <xsl:apply-templates select="@*"/>
+                    </label>
+                    <input type="file" accept="image/png, image/jpeg, image/jpg" id="load_{$imgID}"
+                        name="load_{$imgID}" onchange="loadGraphic(this.files[0],'{ $imgID }','{ string(@xlink:href) }')"/>
+                </form>
+            </p>
+        <img id="{ $imgID }"/>
+        </div>
     </xsl:template>
     
     <xsl:template match="graphic/@*">


### PR DESCRIPTION
Two significant improvements:

- Now loads any non-namespaced document - since JATS is mostly handled (when overlapping STS), there seemed no point in denying it entry. JATS documents now load - YMMV as always.
- Now permits the user to load images into the view for `graphic` elements in display. (Inline graphics are not yet supported.)

### Completeness checklist:

Within the scope of work,

- [x] All readme files and documentation resources are current
- [x] Initial comments look reasonable
- [x] Everything touched has been checked for parsing as appropriate (wf/valid)
- [x] Everything is tested in multiple browsers (minimally: FF and Chrome)
- [x] The top-level directory is current or planned for updating
- [x] As appropriate, outbound external links are marked as `class="external"` (drives popup)

### PR/merge guidelines:

Despite its being a bit cumbersome with respect to commit history, we are using git in a 'safe' mode to avoid potential issues aligning the publication branch, `nist-pages`.

- Merging into `main`, squashing commits in a PR is okay (recommended)
- Don't merge anything into `nist-pages` except `main`, and *never squash* commits in those PRs
- The `main` branch also keeps up with `nist-pages` (merge commits), so after committing to `nist-pages`, pulling back is necessary
