### PR TITLE
STS Checker application in draft (#48)

### DIFF
--- a/directory.xml
+++ b/directory.xml
@@ -9,6 +9,13 @@
             <p>Use this Previewer to see how a NISO STS-tagged document <i>might</i> appear in display (that is, in your browser, cast dynamically from its source tagging).</p>
         </description>
     </project>
+    <project entry="sts-viewer/checker.html">
+        <name>STS Checker</name>
+        <line>How does the STS submission look?</line>
+        <description>
+            <p>An XSLT shows an analytical view of an STS document. Using the <a href="sts-viewer">previewer</a> as a basis, this application provides several views useful for assessing the tagging - its nature and quality - of an STS or JATS/BITS document.</p>
+        </description>
+    </project>
     <project entry="html-reducer">
         <name>HTML Reducer</name>
         <line>Get your Markdown here</line>
@@ -44,13 +51,24 @@
         </description>
     </project>
     <project status="planned">
+        <name>XSLT 1.0-based Schematron-alike</name>
+        <line>Design and test your own rules in your own browser</line>
+        <description>
+            <p>Design your Schematron or a close analog: with this utility and end-user can to compose new rules (using XPath 1.0) and apply them to their own data, without exposure.</p>
+            <p>Not quite a Schematron editor so much as a workbench - although supporting actual Schematron and writing out (saving as) Schematron would be a nice-to-have.</p>
+            <p>This could be nice to have in rudimentary form even if not actual ISO Schematron.</p>
+        </description>
+    </project>
+    <project status="planned">
         <name>OSCAL Boilerplate</name>
         <line>Styling your OSCAL with CSS</line>
         <description>
             <p>Like any XML, OSCAL XML can be displayed in the browser natively, using CSS for layout and typography, almost entirely meeting requirements for many simple applications for document review and the like.</p>
             <p>Where <q>almost entirely</q> isn't enough, a project such as <a href="https://dcl.ils.indiana.edu/teibp/">TEI Boilerplate</a> demonstrates how even a very lightweight XSLT shim can do the rest.</p>
-            <p>In this application, one should be able to load an OSCAL file and then either load or edit CSS and have it applied dynamically. A small accompanying chart would document where the XSLT transformation intervenes to expand text (for example: parameter value insertions), create links or map into HTML directly. This would enable the user effectively to control the entire look/feel of the document as presented, on top of a plain and transparent OSCAL foundation and framing.</p>
         </description>
+        <tldr summary="More details">
+            <p>One should be able to load an OSCAL file and then either load or edit CSS, and have it applied dynamically (laid onto the page). A small 'shim' XSLT transformation could take care of complications such as expanding parameter value insertions, making links etc. With just a little of their own code, the user could effectively control the entire look/feel of the document as presented, on top of a plain and transparent OSCAL foundation and framing. Also it shouldn't matter (or shouldn't matter much) which OSCAL model is being used.</p>
+        </tldr>
     </project>
     <project status="planned">
         <name>OSCAL to STS conversion</name>
@@ -64,19 +82,15 @@
         <line>XSLT, what could go wrong? Risk assessment guidelines and helper application</line>
         <description>
             <p>For more on this topic as it applies to this site, see the <a href="https://github.com/usnistgov/xslt-blender/wiki/Assessment">Assessment</a> page on the project wiki.</p>
+            
+        </description>
+        <tldr summary="An XSLT 1.0 Linter, and then some">
             <p>A transformation offered from a page can help expose and highlight known risks associated with XSLT and the XML-based systems that support them (parser ecosystem etc.) An XSLT loaded by the user can be run through an XSLT, to query and report back on calls and dependencies through static analysis, including (more ideas please) <code>xsl:import</code>, <code>xsl:include</code>, <code>document()</code>, parameter usage etc. - as findings of potential application security vulnerabilities. This could include fine points such as use of <code>xsl:copy</code> passing through unsanitized scripts, etc.</p>
             <p>Such an XSLT diagnostic could also report interesting findings (to code analysts) such as target tag set and namespace; mode usage; key usage; <code>xsl:apply-templates/@select</code> and so forth. (In XSLT 2.0, tunnel parameters, stylesheet variables and micropipelines.) Think of this less as a style guide or (de-)linter, more of an analytic crunch-out/synopsis.</p>
             <p>This can be done separately for XSLT 1.0 and XSLT 3.0, with XSLT 1.0 being an easier lift.</p>
             <p>The page can also cover <q>when you need to assess XSLT</q>, giving attention to the layered architecture and understanding potential threats in context. So you don't end up mistaking the risks or costs and thus losing opportunities.</p>
             <p>Once confirmed, these findings identify vulnerabilities. Those vulnerabilities can inform higher-level risk management about the application and its purpose.</p>
-        </description>
-    </project>
-    <project status="planned">
-        <name>STS Fitness Checking</name>
-        <line>How does the STS submission look?</line>
-        <description>
-            <p>An XSLT can render a document for display; it can also discover and signal where known issues are detected, requirements are not satisfied, or rules are broken.</p>
-        </description>
+        </tldr>
     </project>
     <project status="planned">
         <name>Site Templating</name>

--- a/list-projects.xsl
+++ b/list-projects.xsl
@@ -45,6 +45,15 @@
         </section>
     </xsl:template>
     
+    <xsl:template match="project/tldr">
+        <details class="tldr">
+            <summary>
+                <xsl:value-of select="@summary"/>
+            </summary>
+            <xsl:apply-templates/>
+        </details>
+    </xsl:template>
+    
     <xsl:template match="link">
         <p class="link">
             <a href="{@href}" class="external">

--- a/nist-boilerplate.css
+++ b/nist-boilerplate.css
@@ -2,7 +2,7 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,400;1,700&display=swap');
 
-main.draft { background-image: url( 'draft.svg' ) }
+main.draft, body.draft main { background-image: url( 'draft.svg' ) }
 
 section.project { background-image: none; background-color: white; }
 

--- a/projects-html.css
+++ b/projects-html.css
@@ -1,12 +1,15 @@
 /*  CSS for HTML rendition of project XML */ 
 
-
 .project-directory { display: grid;
 grid-template-columns: repeat(auto-fill, minmax(26em,1fr));
 gap: 0.4em }
 
 section.project {
   border: medium outset lightsteelblue; padding: 1.2em }
+
+.directory section.project { margin-top: 0.8em }
+
+.tldr { margin-top: 0.8em }
 
 section > *:first-child { margin-top: 0em }
 section > button:first-child + * { margin-top: 0em }

--- a/projects-page.xsl
+++ b/projects-page.xsl
@@ -20,7 +20,7 @@
             </head>
             <body>
                 <xsl:call-template name="nist-head"/>
-                <main id="main">
+                <main id="main" class="directory">
                     <h1>XSLT Blender Demonstrations</h1>
                     <xsl:apply-templates/>
                 </main>

--- a/sts-viewer/checker.html
+++ b/sts-viewer/checker.html
@@ -2,14 +2,98 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 
 <head>
-  <title>STS Viewer</title>
+  <title>STS Checker</title>
+  
+  
   <meta charset="utf-8" />
+  
+  
   <style type="text/css" xml:space="preserve">
 
   </style>
   <link rel="stylesheet" href="../nist-boilerplate.css" type="text/css" />
   <link rel="stylesheet" href="../nist-combined.css"/>
   <link rel="stylesheet" href="sts-html.css" type="text/css" />
+  
+  <style type="text/css">
+    
+    #checkerReport { outline: thin solid black; padding: 0.4em; background-color: oldlace; border: medium solid pink; margin-top: 1em }
+    
+    #checkerReport > *:first-child { margin-top: 0em }
+    
+    .outline .xpath { display: inline-block; border: thin solid black; padding: 0.2rem }
+    .inline { display: inline-block }
+    .inline.title { font-weight: bold; padding: 0.2rem; background-color: lightsteelblue; border: thin solid midnightblue }
+    .inline.label { padding: 0.2rem; background-color: black; color: white; border: thin solid black }
+    
+    details.outline { padding-left: 1em }
+    div.outline { margin-left: 1.85em }
+    
+    div.xrefmap { padding: 0.2em; outline: thin dotted black }
+    div.xrefmap:before { content: attr(data-tag); display: inline-block; background-color: black; color: white; font-size: 70% }
+    
+    .citation { line-height: 1.8em }
+    
+    .citation span { padding: 0.2rem; outline: thin dotted black }
+    .citation span:hover { outline: thin solid green; background-color: lightgreen }
+    .citation span.labeled:hover:before { content: attr(data-tag); font-style: normal; padding: 0.2rem; margin-right: 0.2em; background-color: darkgreen; color: white; font-size: 80% }
+    .citation .run-in { font-size: inherit }
+    
+    span.attribute.inline { padding: 0.2rem; outline: thin solid black; padding-right: 0.4rem }
+    span.attrs .inline { margin-right: 0.4em }
+    
+    span.attribute.inline:before { content: attr(data-gi); padding: 0.2rem; background-color: black; color: white; font-size: 80%; margin-right: 0.4em }
+    
+    div.xrefmap p { display: inline; background-color: powderblue; padding: 0.3em }
+    
+    div.xrefmap p > span { background-color: gainsboro; margin: 0.2em }
+    
+    div.xrefCheck { display: flex; gap: 1em }
+    
+    details.reportView summary { margin: 0.6em 0em }
+    
+    details.reportView .outline summary { margin: 0em }
+
+    .reportView .view { display: flex; flex-wrap: wrap; gap: 0.4em }
+    
+    .report { outline: thin solid black; padding: 0.4em; margin-top: 1em; background-color: white }
+
+    div.view { margin-top: 0.6em }
+    .view .report { max-width: 36em; margin: 0em }
+
+    details.xrefGroup { outline: thin dotted black; padding: 0em; }
+  
+    details.xrefGroup summary { background-color: lavender;
+      padding: 0.2em; margin: 0em; }
+  
+    div.xrefCheck p { margin: 0em }
+    
+    p.xref { display: grid; grid-template-columns: 6fr 3fr 1fr; max-width: 54em;
+      outline: thin solid black; padding: 0.2em;}
+    
+    p.xref span { }
+    
+    .xrefRid { font-family: monospace }
+    
+    .error { background-color: yellow; color: red; font-weight: bold }
+    .warning { background-color: yellow; color: orange; font-weight: bold }
+    
+    /* div.outline.fn { display: inline-block; margin: 0em } */
+    
+    
+    .outline .xpath, .xrefCheck .xpath { display: inline-block; border: thin solid black; padding: 0.2rem }
+    .outline .xpath, .xrefCheck .xpath { color: grey }
+    .outline .xpath:hover, .xrefCheck .xpath:hover { color: black; background-color: white }
+    
+    
+    .xref span.xpath,
+    .xref span.error,
+    .xref span.warning { grid-column: 1 / -1; }
+    
+    tt.c:hover { cursor: copy }
+    tt.c:active { color: forestgreen; cursor: grabbing }
+    
+  </style>
   <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script type="text/javascript" id="MathJax-script" async="async"
   src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
@@ -36,57 +120,32 @@
       for (const eachFile of fileSet) {
         const maybeSTSXML = await fileXMLContent(eachFile);
         if (maybeSTSXML) {
-          viewAndShowXML(maybeSTSXML, "displaySTS");
+          viewAndShowXML(maybeSTSXML, "checkedSTS");
         }
       }
     }
 
     async function viewAndShowXML(xmlDocument, targetID) {
       // move this up outside the function call for memoability?
-      const viewerXSLTEngine = await xsltEngineForHREF('sts-view10.xsl');
+      const viewerXSLTEngine = await xsltEngineForHREF('sts-checker.xsl');
       const resultDocument = xslt1ResultDocument(xmlDocument, viewerXSLTEngine); // a promise
       return spliceIntoPage(targetID, resultDocument, true);
     }
-    
-    function loadGraphic(file,graphicID,expectedName) {
-       // const fr = new FileReader();
-       const anURL = URL.createObjectURL(file)
-       const expect = expectedName.split('/').pop().split('#')[0].split('?')[0];
-       const labelClass = ( file.name === expect ? 'aligned' : 'unknown' );
-       document.getElementById('label_'+graphicID).classList.add(labelClass);
-       document.getElementById(graphicID).src = anURL;
-     }
 
-    const viewSection = eID => {
-      let who = document.getElementById(eID); 
-      let openers = getAncestorDetails(who);
-      openers.forEach(o => { o.open = true; } );
-      who.scrollIntoView( {behavior: 'smooth'} );
-    }
-    
-    const getAncestorDetails = el => {
-      let ancestors = [];
-      while (el) {
-        if (el.localName === 'details') { ancestors.unshift(el); }
-        el = el.parentNode;
-      }
-      return ancestors;
-    }
-    
-    
-   const highlightAside = (fnNo) => {
-     const fn = 'fn-' + fnNo;
-     const fnr = 'fnref-' + fnNo;
-     [fn, fnr].forEach( (e) => { document.getElementById(e).classList.toggle("flashing") } );
-   }
-
-   const clearPage = () => {
-     const clearing = document.getElementById('displaySTS');
-     let emptyList = new DataTransfer();
-     let noFiles = emptyList.files;
-     while ( clearing.firstChild && clearing.removeChild(clearing.firstChild) );
+    const clearPage = () => {
+      const clearing = document.getElementById('checkedSTS');
+      let emptyList = new DataTransfer();
+      let noFiles = emptyList.files;
+      while ( clearing.firstChild && clearing.removeChild(clearing.firstChild) );
        document.getElementById("loadSTS").files = noFiles;
      }
+
+
+    const clipboardCopy = async (who) => {
+      let cp = who.innerHTML;
+      try { await navigator.clipboard.writeText(cp); }
+      catch (err) { console.error('Failed to copy: ', err); }
+    }
 
     </script>
         
@@ -127,31 +186,20 @@
     <summary>Is this site a preview, demo, mockup or spoof? - <i><b>How you can know</b></i></summary>
     <p><span>The real site domain ends in <code>nist.gov</code></span>&#xA0;<span>The page address shows <code>https://</code></span></p>
   </details>
-  <main>
-    <h1>STS Viewer</h1>
-    <p>A simple preview of an STS XML document, rendering its structures and text contents into a simple layout for proofing.</p>
-    <p>For an alternative <i>analytic</i> view, in support of data quality assurance and assessment, see the <a href="checker.html">STS Checker</a> utility application.</p>
-    <p>Load your STS XML below: the application does its best to process and display it. All processing is in your browser.</p>
-    <p>Feedback on this demonstration is welcome on the public <a class="external" href="https://github.com/usnistgov/xslt-blender/issues">Github Issues</a> board. Or contribute
-      to community discussions on the public <a class="external" href="https://mulberrytech.com/STS/NISO-STS-List.html">NISO STS List</a> mailing list.</p>
+  <main class="draft">
+    <h1>STS Checker</h1>
+    <p>Load your STS XML document for an analytic summary report of findings and potential issues, produced in your browser. Subject to its limitations, the application will also work on other JATS-based formats such as JATS and BITS.</p>
+    <p>A <a href="index.html">Generic STS Preview</a> utility is also available on this site.</p>
+    <p>Feel free to offer ideas for further development on the public <a class="external" href="https://github.com/usnistgov/xslt-blender/issues">Github Issues</a> board.</p>
     <input type="file" id="loadSTS" name="loadSTS" title="Load STS XML"
       onchange="filterAndShowXMLFiles(this.files)" />
     <button style="float:right" onclick="clearPage()">Clear page</button>
-    <div id="displaySTS"><!-- --></div>
+    <div id="checkedSTS"><!-- --></div>
     <details class="boxed arrayed">
-      <summary>About NISO STS</summary>
-      <p><a class="external" href="https://www.niso.org/standards-committees/sts">NISO STS</a> (ANSI/NISO Z39.102-2017, Standards Tag Suite) is a standardized set of XML tags
-        supporting the creation, maintenance and publication of standards and guidelines documents. Based on work at ISO
-        (International Standards Organization) and the US National Library of Medicine (NIH/NLM/NCBI), NISO STS benefits from participation and adoption by standards development organizations (SDOs), publishers, information service providers, data aggregators, archives and libraries.</p>
-      <p>More resources on this format can be found at the <a href="https://niso-sts.org/">NISO STS Supporting Materials</a> web site.</p>
-      <p>To test this demonstration, a couple of public examples may be tried:</p>
-      <ul>
-        <li><a class="external" href="https://niso-sts.org/downloadables/samples/NISO-STS-Standard-1-0.XML">NISO STS Tag Library</a> in NISO STS</li>
-        <li><a class="external" href="https://niso-sts.org/downloadables/samples/rfc8142.xml">Small example of IETF RFC</a> in NISO STS</li>
-        <li>Or use your own STS XML or best guess (this application does not validate against a schema)</li>
-      </ul>
-      <p>In this demonstration, markers such as <span class="tagLabel">Element</span> indicate elements that have not yet been coded in the transformation. Over time as we add features, these will be seen less frequently.</p>
-      <p>Limitations: basic structures and fallback processing are provided for, but areas are still in need of development. Your examples of valid STS are welcome as use cases for refinement and new features. See the <a class="external" href="https://github.com/usnistgov/xslt-blender">project repository documentation</a> and its <a class="external" href="https://github.com/usnistgov/xslt-blender/issues">Issues board</a>.</p>
+      <summary>About the Checker</summary>
+      <p>See the <a href="index.html">STS Viewer</a> for a reading (preview) display for STS XML.</p>
+      <p>This application produces several analytic views of a NISO STS document (an XML document nominally valid and conformant to NISO STS tagging standards). These analytic views are provided in support of data and encoding quality assessment, especially analysis and assessments that can be aided, but not performed, under automation.</p>
+      <p>This checker comes without warranty or guarantee, but may prove useful to the extent its findings are meaningful and accurate. Everything proposed by the checker  should be considered unconfirmed until checked against. In particular, the 'checking' (representation) provided by this application is unrelated to the nominal <i>validation</i> of any instance against any schema, whether provided, directed or implied. It provides checking against its own criteria, as documented.</p>
       <p>NISO, the <a href="https://niso.org/">National Information Standards Organization</a>, is a nonprofit membership organization that publishes technical standards related to information management, processing, and exchange. NISO has no affiliation with NIST, the <a href="https?//nist.gov">National Institute for Standards and Technology</a>, a Bureau of the US Department of Commerce. This project is developed at NIST in support of public use of a non-proprietary encoding technology illustrating the power of external specification in combination with declarative design principles.</p>
       <p>This viewer application is maintained on <a class="external" href="https://github.com/usnistgov/xslt-blender/tree/main/sts-viewer">Github, with documentation</a>.</p>
    </details>
@@ -162,7 +210,7 @@
       <p>The best way to ensure access to the application over the long term is to replicate it. See the <a class="external" href="https://github.com/usnistgov/xslt-blender/wiki/Maintenance-and-Support">project wiki page on Maintenance and Support</a> for more details on how these projects are designed to be standards-based, accessible, portable, adaptable over time and unhindered by practical impediments to wide deployment, either technical or legal.</p></details>
   </main>
   <div class="project-footer">
-    <p><i>STS Viewer</i> is an <a  href="https://pages.nist.gov/xslt-blender">XSLT Blender</a> project using XSLT 1.0 capabilities built into your browser, with no external dependencies.</p>
+    <p><i>STS Checker</i> is an <a  href="https://pages.nist.gov/xslt-blender">XSLT Blender</a> project using XSLT 1.0 capabilities built into your browser, with no external dependencies.</p>
     <p>Disclaimers apply; no warranty should or can be assumed.</p>
     <p>See the code and contact the developers in the <a class="external" 
       href="https://github.com/usnistgov/xslt-blender">project repository</a>.</p>

--- a/sts-viewer/sts-checker.xsl
+++ b/sts-viewer/sts-checker.xsl
@@ -1,0 +1,370 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns="http://www.w3.org/1999/xhtml"
+    version="1.0">
+    
+    <xsl:import href="sts-view10.xsl"/>
+
+    <!--<xsl:output indent="true"/>-->
+    
+    <xsl:template match="front"/>
+    
+    <!--
+    ideas:
+    
+    x figures and tables
+    ? footnotes
+    References - colors?
+      summary list of elements by type found in mixed-citation
+   
+    external links
+    x internal cross-references
+    
+    -->
+    <xsl:template match="/*">
+        <div id="checkerReport">
+            <h1>Checker report</h1>
+            <details class="outliner reportView">
+                <summary>Outline</summary>
+                <xsl:call-template name="outline-description"/>
+                <xsl:apply-templates select="child::*" mode="outliner"/>
+            </details>
+            <xsl:variable name="checkResults">
+                        <xsl:apply-templates select="/descendant::xref[not(@ref-type)][1]" mode="checkxref-group">
+                            <xsl:with-param name="us" select="/descendant::xref[not(@ref-type)]"/>
+                        </xsl:apply-templates>
+                        <xsl:apply-templates select="$xref-groupers" mode="checkxref-group">
+                            <xsl:sort select="@ref-type"/>
+                        </xsl:apply-templates>
+                    </xsl:variable>
+            <details class="reportView">
+                <summary>Questionable cross-references (<tt class="xpath">xref</tt>)</summary>
+                <div class="xrefCheck">
+                    <!--<xsl:call-template name="report-broken-xrefs"/>-->
+                    <xsl:copy-of select="$checkResults"/>
+                    <xsl:if test="not(normalize-space(string($checkResults)))">
+                        <xsl:variable name="xrefs" select="//xref"/>
+                        <xsl:choose>
+                            <xsl:when test="boolean($xrefs[2])">
+                                <p>
+                                    <b>Congratulations</b>
+                                    <xsl:text>, all </xsl:text>
+                                    <xsl:value-of select="count(//xref)"/>
+                                    <xsl:text> cross-references check out.</xsl:text>
+                                    <span class="xpath">
+                                        <tt class="c" onclick="clipboardCopy(this);">/descendant::xref</tt>
+                                    </span>
+                                </p>
+                            </xsl:when>
+                            <xsl:when test="boolean($xrefs[1])">
+                                <p>The single cross-reference checks out. </p>
+                                <xsl:apply-templates select="$xrefs[1]" mode="xpathme"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <p>No cross-references to check.</p>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:if>
+                </div>
+            </details>
+            <xsl:if test="//fig">
+                <details class="reportView">
+                    <summary>Figures (<tt class="tag">fig</tt>)</summary>
+                    <div class="view">
+                      <xsl:apply-templates select="//fig" mode="report"/>
+                    </div>
+                </details>
+            </xsl:if>
+            <xsl:if test="//table-wrap | //table[not(ancestor::table-wrap)]">
+                <details class="reportView">
+                    <summary>Tables (<tt class="tag">table</tt> with <tt>table-wrap</tt>)</summary>
+                    <xsl:apply-templates select="//table-wrap | //table[not(ancestor::table-wrap)]" mode="report"/>
+                </details>
+            </xsl:if>
+            <xsl:if test="//ref">
+                <details class="reportView">
+                    <summary>References (<tt class="tag">ref</tt>)</summary>
+                    <xsl:apply-templates select="//ref" mode="report"/>
+                </details>
+            </xsl:if>
+            <xsl:if test="//ext-link[not(ancestor::ref)]">
+                <details class="reportView">
+                    <summary>External links outside references (<tt class="tag">ext-link[not(ancestor::ref)]</tt>)</summary>
+                    <div class="view">
+                    <xsl:apply-templates select="//ext-link[not(ancestor::ref)]" mode="report"/>
+                    </div>
+                </details>
+            </xsl:if>
+        </div>
+    </xsl:template>
+    
+    <xsl:template mode="report" match="*">
+        <div class="report">
+            <xsl:call-template name="xpathme"/>
+            <div class="view">
+                <xsl:apply-templates select="."/>
+            </div>
+        </div>
+    </xsl:template>
+    
+    <xsl:template mode="report" match="ref">
+        <div class="report">
+            <span class="attrs"><xsl:apply-templates select="@*" mode="inline"/></span>
+            <xsl:call-template name="xpathme"/>
+            <div class="view">
+                <xsl:apply-templates select="."/>
+            </div>
+        </div>
+    </xsl:template>
+    
+    <xsl:template match="graphic">
+        <div class="graphicBox">
+            <xsl:text>Graphic</xsl:text>
+            <xsl:apply-templates select="@*"/>
+        </div>
+    </xsl:template>
+    
+    <xsl:template match="table[not(ancestor::table-wrap)]">
+        <details class="freeTableBox">
+            <summary>
+            <xsl:text>Table</xsl:text>
+            </summary>
+            <xsl:apply-imports/>
+        </details>
+    </xsl:template>
+    
+    <xsl:template match="table-wrap">
+        <details>
+            <xsl:apply-templates select="@*"/>            
+            <xsl:call-template name="add.class"/>
+            <xsl:apply-templates select="." mode="sec.head"/>
+            <xsl:apply-templates/>
+        </details>
+    </xsl:template>
+    
+    <!--<xsl:template name="report-broken-xrefs">
+        <xsl:variable name="brokens" select="//xref[not(key('by-id',@rid))]"/>
+        <xsl:if test="$brokens">
+        <details class="xrefGroup">
+            <summary>Broken <tt>xref/@rid</tt>
+                <xsl:text> </xsl:text>
+                <xsl:value-of select="concat(' (', count($brokens), ')')"/>
+            </summary>
+            <xsl:apply-templates select="$brokens" mode="checkxref"/>
+        </details>
+        </xsl:if>
+    </xsl:template>-->
+    
+    <xsl:key name="xref-by-reftype" match="xref" use="@ref-type"/>
+    
+    <xsl:variable name="xref-groupers" select="/descendant::xref[generate-id(.) = generate-id(key('xref-by-reftype',@ref-type)[1])]"/>
+    
+    <xsl:template mode="checkxref-group" match="xref">
+        <xsl:param name="us" select="key('xref-by-reftype',@ref-type)"/>
+        <xsl:variable name="mine">
+            <xsl:apply-templates select="$us" mode="checkxref"/>
+        </xsl:variable>
+        <xsl:if test="normalize-space(string($mine))">
+        <details class="xrefGroup">
+            <summary>
+                <tt>@ref-type</tt>
+                <xsl:text> </xsl:text>
+                <xsl:value-of select="@ref-type"/>
+                <xsl:if test="not(normalize-space(string(@ref-type)))">[NONE]</xsl:if>
+            </summary>
+            <xsl:copy-of select="$mine"/>
+        </details>
+        </xsl:if>
+    </xsl:template>
+    
+    <xsl:template name="outline-description">
+        <p class="outlineDescription">Showing anything with <tt class="tag">child::label</tt> or <tt class="tag"
+                >child::title</tt> except <tt class="tag">fn</tt>, <tt class="tag">ref</tt> and <tt
+                class="tag">list-item</tt>.</p>
+    </xsl:template>
+    
+    <xsl:template match="*[.//title or .//label]" mode="outliner">
+        <xsl:variable name="further">
+            <xsl:apply-templates mode="outliner"/>
+        </xsl:variable>
+        <xsl:variable name="outline-text">
+            <xsl:apply-templates select="label" mode="inline"/>
+            <xsl:apply-templates select="@id" mode="inline"/>
+            <xsl:apply-templates select="title" mode="inline"/>
+            <xsl:call-template name="xpathme"/>
+        </xsl:variable>
+        <xsl:choose>
+            <xsl:when test="normalize-space(string($further))">
+                <details class="outline { local-name() }">
+                    <summary>
+                        <xsl:copy-of select="$outline-text"/>
+                    </summary>
+                    <xsl:copy-of select="$further"/>
+                </details>
+            </xsl:when>
+            <xsl:when test="title | label">
+                <div class="outline { local-name() }">
+                    <xsl:copy-of select="$outline-text"/>
+                </div>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!--<xsl:template mode="outliner" match="body | back" priority="101">
+        <div class="outline { local-name() }">
+            <xsl:apply-templates mode="outliner"/>
+        </div>
+    </xsl:template>--> 
+    
+    <xsl:template mode="outliner" match="list-item" priority="9">
+        <xsl:apply-templates mode="outliner"/>
+    </xsl:template>
+    
+    <xsl:template mode="outliner" match="ref | fn" priority="9"/>
+    
+    <xsl:template match="* | text()" mode="outliner"/>
+    
+    <xsl:template mode="inline" match="*">
+        <span class="{ local-name() } inline">
+            <xsl:apply-templates/>
+        </span>
+    </xsl:template>
+    
+    <xsl:template mode="inline" match="@*">
+        <span class="{ local-name() } attribute inline" data-gi="{local-name()}">
+            <xsl:value-of select="."/>
+        </span>
+    </xsl:template>
+    
+    <xsl:template name="xpathme" mode="xpathme" match="*">
+        <span class="xpath">
+            <tt class="c" onclick="clipboardCopy(this);">
+              <xsl:apply-templates select="." mode="path"/>
+            </tt>
+        </span>
+    </xsl:template>
+    
+    <xsl:template match="/" mode="path"/>
+    
+    <xsl:template match="@*" mode="path">
+        <xsl:apply-templates select=".." mode="path"/>
+        <xsl:text>/@</xsl:text>
+        <xsl:value-of select="name()"/>
+    </xsl:template>
+    
+    <!--<xsl:template mode="path" match="*[@id]" priority="1001">
+        <xsl:apply-templates select=".." mode="path"/>
+        <xsl:text>/</xsl:text>
+        <xsl:value-of select="name()"/>
+    </xsl:template>-->
+    
+    <xsl:template mode="path" match="*">
+        <xsl:apply-templates select=".." mode="path"/>
+        <xsl:variable name="myname" select="name()"/>
+        <xsl:text>/</xsl:text>
+        <xsl:value-of select="name()"/>
+        <xsl:if test="count(../child::*[name() = $myname]) > 1">
+            <xsl:text>[</xsl:text>
+            <xsl:value-of select="count(. | preceding-sibling::*[name() = $myname])"/>
+            <xsl:text>]</xsl:text>
+        </xsl:if>
+    </xsl:template>
+    
+    <xsl:template mode="path" match="comment()">
+        <xsl:apply-templates select=".." mode="path"/>
+        <xsl:text>/comment()</xsl:text>
+        <xsl:if test="not(count(../comment()) = 1)">
+            <xsl:text>[</xsl:text>
+            <xsl:value-of select="count(. | preceding-sibling::comment())"/>
+            <xsl:text>]</xsl:text>
+        </xsl:if>
+    </xsl:template>
+    
+    <xsl:template mode="path" match="processing-instruction()">
+        <xsl:apply-templates select=".." mode="path"/>
+        <xsl:text>/comment()</xsl:text>
+        <xsl:if test="not(count(../processing-instruction()) = 1)">
+            <xsl:text>[</xsl:text>
+            <xsl:value-of select="count(. | preceding-sibling::processing-instruction())"/>
+            <xsl:text>]</xsl:text>
+        </xsl:if>
+    </xsl:template>
+    
+    <!--<xsl:template mode="checkxref" match="*[not(.//xref)]"/>
+    
+    <xsl:template mode="checkxref" match="text()">
+        <xsl:if test="../xref">
+            <xsl:value-of select="."/>
+        </xsl:if>
+    </xsl:template>
+    
+    <xsl:template match="*" mode="checkxref">
+        <div class="xrefmap { local-name() }" data-tag="{ local-name() }">
+            <xsl:apply-templates mode="checkxref"/>
+        </div>
+    </xsl:template>-->
+    
+    <xsl:key name="by-id" match="*[@id]" use="@id"/>
+    
+    <xsl:template priority="101" match="xref" mode="checkxref">
+        <xsl:variable name="target" select="key('by-id',@rid)"/>
+        <xsl:variable name="targetType">
+          <xsl:apply-templates select="$target" mode="targetType"/>
+        </xsl:variable>
+        <xsl:if test="not($target) or not(@ref-type = $targetType)">
+            <p class="xref">
+                <span class="xrefContent">
+                    <xsl:apply-templates/>
+                </span>
+                <span class="xrefRid">
+                    <xsl:value-of select="@rid"/>
+                </span>
+                <xsl:choose>
+                    <xsl:when test="not(normalize-space(string(@rid)))">
+                        <span class="error"><tt class="xpath">@rid</tt> is missing or empty</span>
+                    </xsl:when>
+                    <xsl:when test="contains(normalize-space(string(@rid)), ' ')">
+                        <span class="warning">CHECKER DOES NOT SUPPORT MULTIPLE <tt class="xpath"
+                                >@rid</tt></span>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:choose>
+                            <xsl:when test="not(key('by-id', @rid))">
+                                <span class="error"><tt class="xpath">@rid</tt> target is not
+                                    found</span>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <span class="xrefType">
+                                    <xsl:value-of select="@ref-type"/>
+                                </span>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <xsl:choose>
+                    <xsl:when test="not(normalize-space(string(@ref-type)))">
+                        <span class="error"><tt class="xpath">xref/@ref-type</tt> is not given</span>
+                    </xsl:when>
+                    <xsl:when test="not(@ref-type = $targetType)">
+                        <span class="error"><tt class="xpath">xref/@ref-type</tt> is <xsl:value-of
+                                select="@ref-type"/>; expecting <xsl:value-of select="$targetType"
+                            /></span>
+                    </xsl:when>
+                </xsl:choose>
+
+                <xsl:call-template name="xpathme"/>
+            </p>
+        </xsl:if>
+    </xsl:template>
+    
+    <xsl:template mode="targetType" match="*">
+        <xsl:value-of select="local-name()"/>
+    </xsl:template>
+    
+    <xsl:template mode="targetType" match="ref">bibr</xsl:template>
+    
+    <xsl:template mode="targetType" match="table-wrap">table</xsl:template>
+    
+    
+    
+</xsl:stylesheet>


### PR DESCRIPTION
With top-level directory updates

The new STS Checker application performs a few chores useful for examining and assessing data (tagging) quality of STS and other JATS/BITS-based documents, in the browser.

### Completeness checklist:

Within the scope of work,

- [x] All readme files and documentation resources are current
- [x] Initial comments look reasonable
- [x] Everything touched has been checked for parsing as appropriate (wf/valid)
- [x] Everything is tested in multiple browsers (minimally: FF and Chrome)
- [x] The top-level directory is current or planned for updating
- [x] As appropriate, outbound external links are marked as `class="external"` (drives popup)

### PR/merge guidelines:

Despite its being a bit cumbersome with respect to commit history, we are using git in a 'safe' mode to avoid potential issues aligning the publication branch, `nist-pages`.

- Merging into `main`, squashing commits in a PR is okay (recommended)
- Don't merge anything into `nist-pages` except `main`, and *never squash* commits in those PRs
- The `main` branch also keeps up with `nist-pages` (merge commits), so after committing to `nist-pages`, pulling back is necessary
