### PR TITLE
OSCAL Styler demo, first cut

### DIFF
--- a/directory.xml
+++ b/directory.xml
@@ -8,12 +8,12 @@
             <p>This is a <q>fiddle</q> application permitting users to provide and edit XSLT 1.0 and CSS, and apply it in the browser to OSCAL that they also provide themselves. This can actually be useful, and not only for demonstration.</p>
         </description>
     </project>
-    <project status="planned">
+    <project status="oscal-styler/painter.html">
         <name>OSCAL Painter</name>
         <line>Less lines, more color</line>
         <description>
-            <p>This will be a reduced version of the <b>OSCAL Styler</b>, except the XSLT will be hard-coded to show a kind of OSCAL 'boilerplate' in the HTML result, given only enough transformation to be visible in the DOM, usefully supported by HTML semantics (e.g. linking), and addressable by CSS.</p>
-            <p>The approach to here takes inspiration from <a href="https://dcl.ils.indiana.edu/teibp/">TEI Boilerplate</a>.</p>
+            <p>A reduced version of the <b>OSCAL Styler</b> with a hard-coded transformation (XSLT) showing an OSCAL-alike 'boilerplate' in the HTML result, i.e. given only enough transformation to be visible in the DOM and addressable by CSS.</p>
+            <p>The approach to here takes inspiration from <a class="external" href="https://dcl.ils.indiana.edu/teibp/">TEI Boilerplate</a>. See <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Components/Using_custom_elements" class="external">Mozilla Developer Network</a> on custom HTML elements.</p>
         </description>
     </project>
     <project entry="sts-viewer">

--- a/directory.xml
+++ b/directory.xml
@@ -8,7 +8,7 @@
             <p>This is a <q>fiddle</q> application permitting users to provide and edit XSLT 1.0 and CSS, and apply it in the browser to OSCAL that they also provide themselves. This can actually be useful, and not only for demonstration.</p>
         </description>
     </project>
-    <project status="oscal-styler/painter.html">
+    <project entry="oscal-styler/painter.html">
         <name>OSCAL Painter</name>
         <line>Less lines, more color</line>
         <description>

--- a/directory.xml
+++ b/directory.xml
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="projects-page.xsl"?>
 <projects>
+    <project entry="oscal-styler">
+        <name>OSCAL Styler</name>
+        <line>XSLT like it's 1999</line>
+        <description>
+            <p>This is a <q>fiddle</q> application permitting users to provide and edit XSLT 1.0 and CSS, and apply it in the browser to OSCAL that they also provide themselves. This can actually be useful, and not only for demonstration.</p>
+        </description>
+    </project>
+    <project status="planned">
+        <name>OSCAL Painter</name>
+        <line>Less lines, more color</line>
+        <description>
+            <p>This will be a reduced version of the <b>OSCAL Styler</b>, except the XSLT will be hard-coded to show a kind of OSCAL 'boilerplate' in the HTML result, given only enough transformation to be visible in the DOM, usefully supported by HTML semantics (e.g. linking), and addressable by CSS.</p>
+            <p>The approach to here takes inspiration from <a href="https://dcl.ils.indiana.edu/teibp/">TEI Boilerplate</a>.</p>
+        </description>
+    </project>
     <project entry="sts-viewer">
         <name>NISO STS Viewer</name>
         <line>Preview your NISO STS document</line>
@@ -58,17 +73,6 @@
             <p>Not quite a Schematron editor so much as a workbench - although supporting actual Schematron and writing out (saving as) Schematron would be a nice-to-have.</p>
             <p>This could be nice to have in rudimentary form even if not actual ISO Schematron.</p>
         </description>
-    </project>
-    <project status="planned">
-        <name>OSCAL Boilerplate</name>
-        <line>Styling your OSCAL with CSS</line>
-        <description>
-            <p>Like any XML, OSCAL XML can be displayed in the browser natively, using CSS for layout and typography, almost entirely meeting requirements for many simple applications for document review and the like.</p>
-            <p>Where <q>almost entirely</q> isn't enough, a project such as <a href="https://dcl.ils.indiana.edu/teibp/">TEI Boilerplate</a> demonstrates how even a very lightweight XSLT shim can do the rest.</p>
-        </description>
-        <tldr summary="More details">
-            <p>One should be able to load an OSCAL file and then either load or edit CSS, and have it applied dynamically (laid onto the page). A small 'shim' XSLT transformation could take care of complications such as expanding parameter value insertions, making links etc. With just a little of their own code, the user could effectively control the entire look/feel of the document as presented, on top of a plain and transparent OSCAL foundation and framing. Also it shouldn't matter (or shouldn't matter much) which OSCAL model is being used.</p>
-        </tldr>
     </project>
     <project status="planned">
         <name>OSCAL to STS conversion</name>

--- a/html-reducer/html-to-markdown.xsl
+++ b/html-reducer/html-to-markdown.xsl
@@ -89,6 +89,10 @@
         <xsl:text> |</xsl:text>
     </xsl:template>
 
+    <xsl:template mode="md" priority="1" match="xh:hr | hr">
+        <xsl:text>&#10;-----&#10;</xsl:text>
+    </xsl:template>
+    
     <xsl:template mode="md" priority="1" match="xh:pre | pre">
         <xsl:call-template name="lf"/>
         <xsl:text>```&#10;</xsl:text>

--- a/nist-boilerplate.css
+++ b/nist-boilerplate.css
@@ -19,7 +19,7 @@ main > *:first-child { margin-top: 0em }
 /* relative position keeps the footer block behind the leaving-site popup */
 #nistfootergoeshere { z-index: -1; position: relative }
 
-details.boxed { width: fit-content; padding: 0.4em;
+.boxed { width: fit-content; padding: 0.4em;
     margin: 0.25em 0em}
 
 details.boxed[open] { outline: thin dotted black }

--- a/oscal-styler/cat-catalog.xml
+++ b/oscal-styler/cat-catalog.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- this OSCAL document is valid to the schema here: https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.0/xml/schema/oscal_catalog_schema.xsd -->
+<?xml-stylesheet type="text/xsl" href="oscal-basic-display.xsl"?>
+<catalog xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="abe474a5-26aa-426d-8221-a0508c62dce2">
+   <metadata>
+      <title>OSCAL CATalog</title>
+      <last-modified>2021-07-30T14:54:06.481-04:00</last-modified>
+      <version>0.1</version>
+      <oscal-version>1.0.0</oscal-version>
+   </metadata>
+   <control id="dry.food">
+      <title>Crunchies aka <q>dry food</q></title>
+      <part name="statement">
+         <p>Shelf-stable, dry feline nutriments (<q>dry cat food</q> or <q>crunchies</q>) must be available at all times in an accessible location, with only such wrapping or packaging to make it entertaining to extract (using only teeth and claws), or preferably, open in a bowl. Flavors based on chicken or fish are preferred.</p>
+      </part>
+   </control>
+   <control id="canned.food">
+      <title>Wet cat food</title>
+      <part name="statement">
+         <p>Delicious tasty morsels of canned cat food should be provided at regular intervals in sufficient quantities for all cats to be satisfied.</p>
+      </part>
+      <part name="guidance">
+         <p>Wet cat food may be referred to as <q>cat fud</q> on shopping lists. When not otherwise qualified, <q>cat fud</q> should be taken to refer to wet (i.e., canned) cat food, not dry.</p>
+         <p>Table scraps are not acceptable as wet cat food (or acceptable in general). Prey animals also do not count, although they may also be enjoyed.</p>
+      </part>
+   </control>
+   <control id="kitchen.cabinets">
+      <title>Kitchen Cabinets and drawers</title>
+      <part name="statement">
+         <p>Kitchen drawers and cabinets should be kept closed to prevent feline incursion.</p>
+      </part>
+   </control>
+   <control id="boxes">
+      <title>Boxes</title>
+      <link rel="related" href="#toys"/>
+      <part name="statement">
+         <p>Cardboard or other disposable delivery boxes may be left in the living room as temporary cat fortresses.</p>
+      </part>
+   </control>
+   <control id="treats">
+      <title>Treats</title>
+      <param id="p1">
+         <label>maximum treat allowance</label>
+         <guideline>
+            <p>A natural language description of how many treats are permitted within a given period, to be determine by the cat's <q>owner</q> given appropriate veterinary advice.</p>
+         </guideline>
+      </param>
+      <part name="statement">
+         <p>Treats may be given freely by a feline's caretaker or companion on demand, up to a maximum of <insert type="param" id-ref="p1"/>.</p>
+      </part>
+   </control>
+   <control id="toys">
+      <title>Toys</title>
+      <link rel="related" href="#boxes"/>
+      <part name="statement">
+         <p>Any small objects or objects of any size with holes, passages, hatches or flaps may be considered cat toys, defined as objects designated for feline play. Store-bought cat toys are acceptable but a cat may select its own toys such as string, rubber bands or jewelry.</p>
+      </part>
+   </control>
+</catalog>

--- a/oscal-styler/index.html
+++ b/oscal-styler/index.html
@@ -26,6 +26,7 @@ div.unknown * { margin: 0em}
 
 .editbox { width: 100%; box-sizing: border-box; margin-top: 0.6em; }
 
+.codePanel { min-width: 30vw}
   </style>
   <link rel="stylesheet" href="../nist-boilerplate.css" type="text/css" />
   <link rel="stylesheet" href="../nist-combined.css"/>
@@ -104,6 +105,16 @@ div.unknown * { margin: 0em}
       }
     }
    
+    const clearLoad = (loadButtonID, clearDivID) => {
+      const clearing = document.getElementById(clearDivID);
+      clearing.closest("details").open = false; // close the ancestor details
+      let emptyList = new DataTransfer();
+      let noFiles = emptyList.files;
+      if (clearing.value) { clearing.value =  '' };
+      while ( clearing.firstChild && clearing.removeChild(clearing.firstChild) );
+      document.getElementById(loadButtonID).files = noFiles;
+    }
+
     function refreshPageCSS()  { return true }
 
     async function applyXSLT() {
@@ -170,16 +181,16 @@ div.unknown * { margin: 0em}
   <main class="draft">
     <h1>OSCAL Styler</h1>
     <p>An XSLT 1.0 workbench set up for <a href="https://pages.nist.gov/OSCAL">OSCAL, the Open Security Controls Assessment Language</a>.</p>
-    <p>Load your OSCAL XML below along with XSLT 1.0 and CSS code. Activate <button onclick="document.getElementById('applyButton').click;">Apply Styles</button> and the loaded data will be transformed (using the XSLT) and rendered (using the CSS). Starter XSLTs for the different OSCAL formats produce a fully functional viewer, ready for the user to enhance and modify; start from scratch; or load your own XSLT to test it. No data is sent to any server.</p>
+    <p>Load your OSCAL XML below along with XSLT 1.0 and CSS code. Activate <button onclick="document.getElementById('applyButton').click;">Apply Styles</button> and the loaded data will be transformed using the XSLT and rendered on the page using the CSS. Load your own XSLT to test it, or (soon) load a pre-made XSLT and enhance and modify it in the page, applying it to see the results dynamically. No data is sent to any server.</p>
     <p>The OSCAL Styler is inspired by M. Honnen's awesome <a href="https://martin-honnen.github.io/xslt3fiddle/">XSLT Fiddle</a> (client-side version), which supports advanced XSLT up to XSLT 3.0/3.1 via the SaxonJS library. See also the spare but impressive <a class="external" href="http://i-like-robots.github.io/xslt-fiddle/">XSLT Fiddle</a> by Github user <tt>i-like-robots</tt>.</p>
     <p>Feedback on this demonstration is welcome on the public <a class="external" href="https://github.com/usnistgov/xslt-blender/issues">Github Issues</a> board. Or contribute
       to community discussions in public <a href="https://pages.nist.gov/OSCAL/contact/">OSCAL</a> channels.</p>
     <details class="boxed"><summary>Load and edit styles</summary>
     <div class="panels">
-    <details>
+    <details class="codePanel">
       <summary>XSLT 1.0 <input type="file" accept=".xsl, .xslt" id="loadXSLTButton" name="loadXSLTButton" title="Load OSCAL" onchange="dropFileText(this.files,'XSLTeditbox');this.parentElement.parentElement.open = true;"
       /><!-- pulldown here for loading -->
-        <button style="float:right" onclick="document.getElementById('XSLTeditbox').value = '';">Clear</button></summary>
+        <button style="float:right" onclick="clearLoad('loadXSLTButton','XSLTeditbox');">Clear</button></summary>
       <textarea id="XSLTeditbox" class="editbox" spellcheck="false" rows="48"></textarea>
      
     </details>
@@ -187,10 +198,10 @@ div.unknown * { margin: 0em}
         <button id="applyButton" onclick="applyXSLT(); refreshPageCSS();">Apply&#xA0;Styles</button>
       </div>
       
-    <details>
+    <details class="codePanel">
       <summary>CSS <input type="file" id="loadCSSButton" accept=".css" name="loadCSSButton" title="Load CSS" onchange="dropFileText(this.files,'CSSeditbox');this.parentElement.parentElement.open = true;"
       />
-        <button style="float:right" onclick="document.getElementById('CSSeditbox').value = '';">Clear</button></summary>
+        <button style="float:right" onclick="clearLoad('loadCSSButton','CSSeditbox');">Clear</button></summary>
       <textarea id="CSSeditbox" class="editbox" spellcheck="false" rows="48"></textarea>
       
     </details>
@@ -202,7 +213,7 @@ div.unknown * { margin: 0em}
     <details class="boxed" id="loadOSCALpanel">
       <summary>Load OSCAL <input type="file" id="loadOSCALButton" accept=".xml, .osc, .oscal"  name="loadOSCALButton" title="Load OSCAL"  onchange="loadOSCAL(this.files)" 
       />
-        <button style="float:right" onclick="clearOSCAL()">Clear OSCAL</button></summary>
+        <button style="float:right" onclick="clearLoad('loadOSCALButton','OSCALfile')">Clear OSCAL</button></summary>
       <div id="OSCALfile">
         <!-- x -->
       </div>

--- a/oscal-styler/index.html
+++ b/oscal-styler/index.html
@@ -39,24 +39,28 @@ div.unknown * { margin: 0em}
   <script async="async" type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NIST&subagency=github&pua=UA-66610693-1&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c">
 </script>
   <script type="module">
-      import { fileXMLContent, spliceIntoPage, xslt1ResultDocument, xsltEngineForHREF, parseXMLLiteral } from "../lib/xslt-blender.js";
+      import { fileXMLContent, spliceIntoPage, xsltEngineForHREF, parseXMLLiteral } from "../lib/xslt-blender.js";
+      // import { setupXSLTEngine } from "../lib/xslt-blender.js";
 
       // todo: replace with something a little less cumbersome?
       window.fileXMLContent = fileXMLContent;
       window.spliceIntoPage = spliceIntoPage;
-      window.xslt1ResultDocument = xslt1ResultDocument;
       // window.parseAndTransformXMLLiteral = parseAndTransformXMLLiteral;
       window.xsltEngineForHREF = xsltEngineForHREF;
       window.parseXMLLiteral = parseXMLLiteral;
+      // window.setupXSLTEngine = setupXSLTEngine
 
   </script>
    
    <script type="text/javascript">
      
+    // var loadedOSCAL = New Document();
+
     async function loadOSCAL(fileSet) {
       for (const eachFile of fileSet) {
         const anXML = await fileXMLContent(eachFile);
         if (anXML) {
+          loadedOSCAL = anXML;
           viewAndTransformXMLwithXSLT(anXML, 'show-loaded-xml.xsl', 'OSCALfile');
           document.getElementById('loadOSCALpanel').open = true;
         }
@@ -66,7 +70,7 @@ div.unknown * { margin: 0em}
     async function viewAndTransformXMLwithXSLT(xmlDocument, xsltHREF, targetID) {
       // move this up outside the function call for memoability?
       const viewerXSLTEngine = await xsltEngineForHREF(xsltHREF);
-      const resultDocument = xslt1ResultDocument(xmlDocument, viewerXSLTEngine); // a promise
+      const resultDocument = viewerXSLTEngine.transformToDocument(xmlDocument);
       return spliceIntoPage(targetID, resultDocument, true);
     }
     
@@ -85,7 +89,7 @@ div.unknown * { margin: 0em}
       // instead of simply loading we must parse and load the textbox content, defending w/ try/catch on parsing etc.
       // also can we find CSS to auto-line number a textbox or 'pre' box?
       
-      const resultDocument = xslt1ResultDocument(xmlDocument, viewerXSLTEngine); // a promise
+      const resultDocument = viewerXSLTEngine.transformToDocument(xmlDocument, );
       return spliceIntoPage(targetID, resultDocument, true);
     }
 
@@ -100,7 +104,30 @@ div.unknown * { margin: 0em}
       }
     }
    
+    function refreshPageCSS()  { return true }
+
+    async function applyXSLT() {
+        // const OSCALloadButton = document.getElementById('loadOSCALButton');
+        // const loadedOSCAL = await fileXMLContent(OSCALloadButton.files[0]);
+        const XSLTLiteral = document.getElementById('XSLTeditbox').value;
+        // console.log(XSLTLiteral);
+        if (!loadedOSCAL) { throw new Error('No OSCAL Loaded'); }
+        else {
+          const OSCALxml = loadedOSCAL;
+          const ViewerXSLT = parseXMLLiteral(XSLTLiteral);
+          //console.log(ViewerXSLT);
+          const xsltEngine = new XSLTProcessor();
+          xsltEngine.importStylesheet(ViewerXSLT);
+
+          // const XSLTEngine = setupXSLTEngine(ViewerXSLT);
+          // console.log(XSLTEngine);
+          const resultDocument = xsltEngine.transformToDocument(loadedOSCAL);
+          return spliceIntoPage('displayOSCAL', resultDocument, true);
+          }
+        }
+
     
+
     </script>
         
 </head>

--- a/oscal-styler/index.html
+++ b/oscal-styler/index.html
@@ -102,6 +102,10 @@ div.unknown * { margin: 0em}
       document.getElementById(loadButtonID).files = noFiles;
     }
 
+    function clearDisplay() {
+      document.getElementById('displayFrame').contentDocument.body.replaceChildren()
+    }
+   
     function refreshPageCSS()  { 
       const userCSS = document.getElementById('CSSeditbox').value;
       const frameDocument = document.getElementById('displayFrame').contentDocument;
@@ -202,7 +206,8 @@ div.unknown * { margin: 0em}
   
 
       <details class="boxed fullwidth"><summary>Load and edit styles
-      <button class="applyButton floatButton" onclick="applyXSLT(); refreshPageCSS();">Apply&#xA0;Styles</button>
+        <button class="applyButton floatButton" onclick="applyXSLT(); refreshPageCSS();">Apply&#xA0;Styles</button>
+        <button class="clearButton floatButton" onclick="clearDisplay();">Clear Display</button>
         
     </summary>
     <div class="panels">
@@ -214,13 +219,13 @@ div.unknown * { margin: 0em}
      
     </div>
       
-    <dive class="codePanel">
+    <div class="codePanel">
       <p>CSS <input type="file" id="loadCSSButton" accept=".css" name="loadCSSButton" title="Load CSS" onchange="dropFileText(this.files,'CSSeditbox');this.parentElement.parentElement.open = true;"
       />
         <button class="floatButton" onclick="clearLoad('loadCSSButton','CSSeditbox');">Clear</button></p>
       <textarea id="CSSeditbox" class="editbox" spellcheck="false" rows="48">body { background-color: white }</textarea>
       
-    </dive>
+    </div>
     </div>
     </details>
     

--- a/oscal-styler/index.html
+++ b/oscal-styler/index.html
@@ -10,10 +10,11 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0.8em;
-  margin-top: 1em;
+  margin-top: 0.6em;
   }
   
-.panels > * { display: inline-block; vertical-align: text-top; outline: thin solid black; padding: 0.4em; margin: 0.25em 0em; }
+.panels > * { vertical-align: text-top; outline: thin solid black; padding: 0.4em; margin: 0.25em 0em;
+  background-color: whitesmoke }
 
 .boxed.fullwidth { width: 100% }
 
@@ -23,7 +24,7 @@ div.oscal * { margin: 0em}
 div.unknown { padding: 0.6em; outline: medium inset red; background-color: pink }
 div.unknown * { margin: 0em}
 
-.editbox { width: 100%; box-sizing: border-box; margin-top: 0.6em; resize: both; }
+.editbox { width: 100%; box-sizing: border-box; resize: both; }
 
 .codePanel { min-width: 30vw}
 

--- a/oscal-styler/index.html
+++ b/oscal-styler/index.html
@@ -6,17 +6,16 @@
   <meta charset="utf-8" />
   <style type="text/css" xml:space="preserve" id="pageStyle">
 
-/* .panels {
+ .panels {
   display: grid;
-  grid-template-columns: 1fr min-content 1fr;
-  gap: 0.2em;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.8em;
   margin-top: 1em;
-  } */
+  }
   
 .panels > * { display: inline-block; vertical-align: text-top; outline: thin solid black; padding: 0.4em; margin: 0.25em 0em; }
 
-#applyButtonBox { outline: none }
-#applyButtonBox button { margin: none; font-weight: bold }
+.boxed.fullwidth { width: 100% }
 
 div.oscal { padding: 0.6em; outline: medium inset forestgreen; background-color: lightgreen }
 div.oscal * { margin: 0em}
@@ -24,9 +23,15 @@ div.oscal * { margin: 0em}
 div.unknown { padding: 0.6em; outline: medium inset red; background-color: pink }
 div.unknown * { margin: 0em}
 
-.editbox { width: 100%; box-sizing: border-box; margin-top: 0.6em; }
+.editbox { width: 100%; box-sizing: border-box; margin-top: 0.6em; resize: both; }
 
 .codePanel { min-width: 30vw}
+
+.floatButton { float:right; margin-left: 0.6em }
+
+#displayFrame { width: 100%; height: 62vh }
+
+
   </style>
   <link rel="stylesheet" href="../nist-boilerplate.css" type="text/css" />
   <link rel="stylesheet" href="../nist-combined.css"/>
@@ -55,45 +60,27 @@ div.unknown * { margin: 0em}
    
    <script type="text/javascript">
      
-    // var loadedOSCAL = New Document();
+    let loadedOSCAL = new Document();
 
+    // const showLoadXSLTEngine = new XSLTProcessor();
+    // showLoadXSLTEngine = await xsltEngineForHREF('show-loaded-xml.xsl');
+    
     async function loadOSCAL(fileSet) {
+      const viewerXSLTEngine = await xsltEngineForHREF('show-loaded-xml.xsl');
+          
       for (const eachFile of fileSet) {
         const anXML = await fileXMLContent(eachFile);
         if (anXML) {
           loadedOSCAL = anXML;
-          viewAndTransformXMLwithXSLT(anXML, 'show-loaded-xml.xsl', 'OSCALfile');
+
+          const resultDocument = viewerXSLTEngine.transformToDocument(loadedOSCAL);
+
+          spliceIntoPage('OSCALfile', resultDocument, true);
           document.getElementById('loadOSCALpanel').open = true;
         }
       }
     }
-
-    async function viewAndTransformXMLwithXSLT(xmlDocument, xsltHREF, targetID) {
-      // move this up outside the function call for memoability?
-      const viewerXSLTEngine = await xsltEngineForHREF(xsltHREF);
-      const resultDocument = viewerXSLTEngine.transformToDocument(xmlDocument);
-      return spliceIntoPage(targetID, resultDocument, true);
-    }
     
-    // async function filterAndShowXMLFiles(fileSet, targetID) {
-    //  for (const eachFile of fileSet) {
-    //    const maybeXML = await fileXMLContent(eachFile);
-    //    if (maybeXML) {
-    //      viewAndShowXML(maybeXML, targetID);
-    //    }
-    //  }
-    // }
-
-    async function viewAndShowXML(xmlDocument, targetID) {
-      
-      // const viewerXSLTEngine = await xsltEngineForHREF('sts-view10.xsl');
-      // instead of simply loading we must parse and load the textbox content, defending w/ try/catch on parsing etc.
-      // also can we find CSS to auto-line number a textbox or 'pre' box?
-      
-      const resultDocument = viewerXSLTEngine.transformToDocument(xmlDocument, );
-      return spliceIntoPage(targetID, resultDocument, true);
-    }
-
     function dropFileText(fileSet,whereID) {
       for (const eachFile of fileSet) {
         let where = document.getElementById(whereID)
@@ -107,7 +94,7 @@ div.unknown * { margin: 0em}
    
     const clearLoad = (loadButtonID, clearDivID) => {
       const clearing = document.getElementById(clearDivID);
-      clearing.closest("details").open = false; // close the ancestor details
+      // clearing.closest("details").open = false; // close the ancestor details
       let emptyList = new DataTransfer();
       let noFiles = emptyList.files;
       if (clearing.value) { clearing.value =  '' };
@@ -115,29 +102,47 @@ div.unknown * { margin: 0em}
       document.getElementById(loadButtonID).files = noFiles;
     }
 
-    function refreshPageCSS()  { return true }
+    function refreshPageCSS()  { 
+      const userCSS = document.getElementById('CSSeditbox').value;
+      const frameDocument = document.getElementById('displayFrame').contentDocument;
+      const newStyle = frameDocument.createElement('style');
+      newStyle.setAttribute('id','userCSS');
+      newStyle.append(userCSS);
+      frameDocument.getElementById('userCSS')?.remove();
+      frameDocument.head.append(newStyle);
+      // while (frameDocument.body.firstChild && frameDocument.body.removeChild(frameDocument.body.firstChild));
+      //        return frameDocument.body.append(transformResult);
+      //  return true      
+
+     }
 
     async function applyXSLT() {
         // const OSCALloadButton = document.getElementById('loadOSCALButton');
         // const loadedOSCAL = await fileXMLContent(OSCALloadButton.files[0]);
         const XSLTLiteral = document.getElementById('XSLTeditbox').value;
         // console.log(XSLTLiteral);
-        if (!loadedOSCAL) { throw new Error('No OSCAL Loaded'); }
+        if (!loadedOSCAL) { alert('Please load your OSCAL XML document'); }
         else {
           const OSCALxml = loadedOSCAL;
           const ViewerXSLT = parseXMLLiteral(XSLTLiteral);
-          //console.log(ViewerXSLT);
-          const xsltEngine = new XSLTProcessor();
-          xsltEngine.importStylesheet(ViewerXSLT);
+          const errorNode = ViewerXSLT.querySelector("parsererror");
 
-          // const XSLTEngine = setupXSLTEngine(ViewerXSLT);
-          // console.log(XSLTEngine);
-          const resultDocument = xsltEngine.transformToDocument(loadedOSCAL);
-          return spliceIntoPage('displayOSCAL', resultDocument, true);
+          if (errorNode) {  alert("XSLT Stylesheet does not parse") }
+          else { 
+            const xsltEngine = new XSLTProcessor();
+            try {
+              xsltEngine.importStylesheet(ViewerXSLT);
+              const frameDocument = document.getElementById('displayFrame').contentDocument;
+              const transformResult = xsltEngine.transformToFragment(loadedOSCAL, frameDocument);
+              frameDocument.body.replaceChildren();
+              // while (frameDocument.body.firstChild && frameDocument.body.removeChild(frameDocument.body.firstChild));
+              return frameDocument.body.append(transformResult);
+              // if (resultDocument) { return spliceIntoPage('displayOSCAL', resultDocument, true); }
+              // return .body.append(resultDocument);
+            } catch(e) { alert("Failure applying XSLT 1.0" ); console.log(e); }
           }
         }
-
-    
+    }
 
     </script>
         
@@ -185,41 +190,44 @@ div.unknown * { margin: 0em}
     <p>The OSCAL Styler is inspired by M. Honnen's awesome <a href="https://martin-honnen.github.io/xslt3fiddle/">XSLT Fiddle</a> (client-side version), which supports advanced XSLT up to XSLT 3.0/3.1 via the SaxonJS library. See also the spare but impressive <a class="external" href="http://i-like-robots.github.io/xslt-fiddle/">XSLT Fiddle</a> by Github user <tt>i-like-robots</tt>.</p>
     <p>Feedback on this demonstration is welcome on the public <a class="external" href="https://github.com/usnistgov/xslt-blender/issues">Github Issues</a> board. Or contribute
       to community discussions in public <a href="https://pages.nist.gov/OSCAL/contact/">OSCAL</a> channels.</p>
-    <details class="boxed"><summary>Load and edit styles</summary>
+
+      <details class="boxed" id="loadOSCALpanel">
+        <summary>Load OSCAL <input type="file" id="loadOSCALButton" accept=".xml, .osc, .oscal"  name="loadOSCALButton" title="Load OSCAL"  onchange="loadOSCAL(this.files)" 
+        />
+          <button style="float:right" onclick="loadedOSCAL = undefined; clearLoad('loadOSCALButton','OSCALfile');">Clear OSCAL</button></summary>
+        <div id="OSCALfile">
+          <!-- x -->
+        </div>
+      </details>
+  
+
+      <details class="boxed fullwidth"><summary>Load and edit styles
+      <button class="applyButton floatButton" onclick="applyXSLT(); refreshPageCSS();">Apply&#xA0;Styles</button>
+        
+    </summary>
     <div class="panels">
-    <details class="codePanel">
-      <summary>XSLT 1.0 <input type="file" accept=".xsl, .xslt" id="loadXSLTButton" name="loadXSLTButton" title="Load OSCAL" onchange="dropFileText(this.files,'XSLTeditbox');this.parentElement.parentElement.open = true;"
+    <div class="codePanel">
+      <p>XSLT 1.0 <input type="file" accept=".xsl, .xslt" id="loadXSLTButton" name="loadXSLTButton" title="Load OSCAL" onchange="dropFileText(this.files,'XSLTeditbox');this.parentElement.parentElement.open = true;"
       /><!-- pulldown here for loading -->
-        <button style="float:right" onclick="clearLoad('loadXSLTButton','XSLTeditbox');">Clear</button></summary>
+        <button class="floatButton" onclick="clearLoad('loadXSLTButton','XSLTeditbox');">Clear</button></p>
       <textarea id="XSLTeditbox" class="editbox" spellcheck="false" rows="48"></textarea>
      
-    </details>
-      <div id="applyButtonBox" class="boxed">
-        <button id="applyButton" onclick="applyXSLT(); refreshPageCSS();">Apply&#xA0;Styles</button>
-      </div>
+    </div>
       
-    <details class="codePanel">
-      <summary>CSS <input type="file" id="loadCSSButton" accept=".css" name="loadCSSButton" title="Load CSS" onchange="dropFileText(this.files,'CSSeditbox');this.parentElement.parentElement.open = true;"
+    <dive class="codePanel">
+      <p>CSS <input type="file" id="loadCSSButton" accept=".css" name="loadCSSButton" title="Load CSS" onchange="dropFileText(this.files,'CSSeditbox');this.parentElement.parentElement.open = true;"
       />
-        <button style="float:right" onclick="clearLoad('loadCSSButton','CSSeditbox');">Clear</button></summary>
-      <textarea id="CSSeditbox" class="editbox" spellcheck="false" rows="48"></textarea>
+        <button class="floatButton" onclick="clearLoad('loadCSSButton','CSSeditbox');">Clear</button></p>
+      <textarea id="CSSeditbox" class="editbox" spellcheck="false" rows="48">body { background-color: white }</textarea>
       
-    </details>
+    </dive>
     </div>
     </details>
     
-    <button style="float:right" onclick="applyXSLT(); refreshPageCSS();">Apply&#xA0;Styles</button>
-    
-    <details class="boxed" id="loadOSCALpanel">
-      <summary>Load OSCAL <input type="file" id="loadOSCALButton" accept=".xml, .osc, .oscal"  name="loadOSCALButton" title="Load OSCAL"  onchange="loadOSCAL(this.files)" 
-      />
-        <button style="float:right" onclick="clearLoad('loadOSCALButton','OSCALfile')">Clear OSCAL</button></summary>
-      <div id="OSCALfile">
-        <!-- x -->
-      </div>
-    </details>
-    
-    <div id="displayOSCAL"><!-- --></div>
+    <iframe name="displayFrame" id="displayFrame">Loading frame ...</iframe>
+
+  </div>
+
     <details class="boxed arrayed">
       <summary>Who is this for</summary>
       <ul>

--- a/oscal-styler/index.html
+++ b/oscal-styler/index.html
@@ -189,7 +189,7 @@ div.unknown * { margin: 0em}
       to community discussions in public <a href="https://pages.nist.gov/OSCAL/contact/">OSCAL</a> channels.</p>
 
       <details class="boxed" id="loadOSCALpanel">
-        <summary>Load OSCAL <input type="file" id="loadOSCALButton" accept=".xml, .osc, .oscal"  name="loadOSCALButton" title="Load OSCAL"  onchange="loadOSCAL(this.files); this.closest('details').open = true;" 
+        <summary>Load OSCAL XML <input type="file" id="loadOSCALButton" accept=".xml, .osc, .oscal"  name="loadOSCALButton" title="Load OSCAL"  onchange="loadOSCAL(this.files); this.closest('details').open = true;" 
         />
           <button style="float:right" onclick="loadedOSCAL = undefined; clearLoad('loadOSCALButton','OSCALfile');">Clear OSCAL</button></summary>
         <div id="OSCALfile">

--- a/oscal-styler/index.html
+++ b/oscal-styler/index.html
@@ -148,6 +148,20 @@ div.unknown * { margin: 0em}
         }
     }
 
+    
+    // mainly cribbed from https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Fetching_data
+    function acquireXSLT(HREF,targetID) { 
+        const target = document.getElementById(targetID);
+        fetch(HREF) // returns a promise
+        .then((response) => {
+            if (!response.ok) {  throw new Error(`HTTP error: ${response.status}`); }
+            return response.text();
+        })
+        .then((text) => { target.value = text;  })
+        .catch((error) => { console.log = `Could not fetch XSLT from ${HREF}: ${error}`; }
+        );
+    }
+
     </script>
         
 </head>
@@ -214,6 +228,7 @@ div.unknown * { margin: 0em}
     <div class="codePanel">
       <p>XSLT 1.0 <input type="file" accept=".xsl, .xslt" id="loadXSLTButton" name="loadXSLTButton" title="Load OSCAL" onchange="dropFileText(this.files,'XSLTeditbox');this.parentElement.parentElement.open = true;"
       /><!-- pulldown here for loading -->
+        <button class="floatButton" onclick="acquireXSLT('oscal-basic-display.xsl','XSLTeditbox');">Load starter OSCAL XSLT 1.0</button>
         <button class="floatButton" onclick="clearLoad('loadXSLTButton','XSLTeditbox');">Clear</button></p>
       <textarea id="XSLTeditbox" class="editbox" spellcheck="false" rows="48"></textarea>
      

--- a/oscal-styler/index.html
+++ b/oscal-styler/index.html
@@ -36,7 +36,6 @@ div.unknown * { margin: 0em}
   </style>
   <link rel="stylesheet" href="../nist-boilerplate.css" type="text/css" />
   <link rel="stylesheet" href="../nist-combined.css"/>
-  <link rel="stylesheet" href="sts-html.css" type="text/css" />
   <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script type="text/javascript" id="MathJax-script" async="async"
   src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">

--- a/oscal-styler/index.html
+++ b/oscal-styler/index.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+
+<head>
+  <title>OSCAL Styler</title>
+  <meta charset="utf-8" />
+  <style type="text/css" xml:space="preserve" id="pageStyle">
+
+/* .panels {
+  display: grid;
+  grid-template-columns: 1fr min-content 1fr;
+  gap: 0.2em;
+  margin-top: 1em;
+  } */
+  
+.panels > * { display: inline-block; vertical-align: text-top; outline: thin solid black; padding: 0.4em; margin: 0.25em 0em; }
+
+#applyButtonBox { outline: none }
+#applyButtonBox button { margin: none; font-weight: bold }
+
+div.oscal { padding: 0.6em; outline: medium inset forestgreen; background-color: lightgreen }
+div.oscal * { margin: 0em}
+
+div.unknown { padding: 0.6em; outline: medium inset red; background-color: pink }
+div.unknown * { margin: 0em}
+
+.editbox { width: 100%; box-sizing: border-box; margin-top: 0.6em; }
+
+  </style>
+  <link rel="stylesheet" href="../nist-boilerplate.css" type="text/css" />
+  <link rel="stylesheet" href="../nist-combined.css"/>
+  <link rel="stylesheet" href="sts-html.css" type="text/css" />
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script type="text/javascript" id="MathJax-script" async="async"
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+</script>
+  <!-- https://github.com/usnistgov/pages-root/wiki/Adding-NIST-required-branding-and-features-to-your-site -->
+  <!-- Google analytics    -->
+  <script async="async" type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NIST&subagency=github&pua=UA-66610693-1&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c">
+</script>
+  <script type="module">
+      import { fileXMLContent, spliceIntoPage, xslt1ResultDocument, xsltEngineForHREF, parseXMLLiteral } from "../lib/xslt-blender.js";
+
+      // todo: replace with something a little less cumbersome?
+      window.fileXMLContent = fileXMLContent;
+      window.spliceIntoPage = spliceIntoPage;
+      window.xslt1ResultDocument = xslt1ResultDocument;
+      // window.parseAndTransformXMLLiteral = parseAndTransformXMLLiteral;
+      window.xsltEngineForHREF = xsltEngineForHREF;
+      window.parseXMLLiteral = parseXMLLiteral;
+
+  </script>
+   
+   <script type="text/javascript">
+     
+    async function loadOSCAL(fileSet) {
+      for (const eachFile of fileSet) {
+        const anXML = await fileXMLContent(eachFile);
+        if (anXML) {
+          viewAndTransformXMLwithXSLT(anXML, 'show-loaded-xml.xsl', 'OSCALfile');
+          document.getElementById('loadOSCALpanel').open = true;
+        }
+      }
+    }
+
+    async function viewAndTransformXMLwithXSLT(xmlDocument, xsltHREF, targetID) {
+      // move this up outside the function call for memoability?
+      const viewerXSLTEngine = await xsltEngineForHREF(xsltHREF);
+      const resultDocument = xslt1ResultDocument(xmlDocument, viewerXSLTEngine); // a promise
+      return spliceIntoPage(targetID, resultDocument, true);
+    }
+    
+    // async function filterAndShowXMLFiles(fileSet, targetID) {
+    //  for (const eachFile of fileSet) {
+    //    const maybeXML = await fileXMLContent(eachFile);
+    //    if (maybeXML) {
+    //      viewAndShowXML(maybeXML, targetID);
+    //    }
+    //  }
+    // }
+
+    async function viewAndShowXML(xmlDocument, targetID) {
+      
+      // const viewerXSLTEngine = await xsltEngineForHREF('sts-view10.xsl');
+      // instead of simply loading we must parse and load the textbox content, defending w/ try/catch on parsing etc.
+      // also can we find CSS to auto-line number a textbox or 'pre' box?
+      
+      const resultDocument = xslt1ResultDocument(xmlDocument, viewerXSLTEngine); // a promise
+      return spliceIntoPage(targetID, resultDocument, true);
+    }
+
+    function dropFileText(fileSet,whereID) {
+      for (const eachFile of fileSet) {
+        let where = document.getElementById(whereID)
+        let frdr = new FileReader();
+        frdr.onload = function () {
+          where.value = frdr.result
+        }
+        frdr.readAsText(eachFile);
+      }
+    }
+   
+    
+    </script>
+        
+</head>
+
+<body>
+  <div id="nistheadergoeshere">
+    <header class="nist-header" id="nist-header" role="banner">
+      
+      <a href="https://www.nist.gov/"
+        title="National Institute of Standards and Technology"
+        class="nist-header__logo-link" rel="home">
+        <svg aria-hidden="true" class="nist-header__logo-icon" version="1.1"
+          xmlns="http://www.w3.org/2000/svg" width="24" height="32"
+          viewBox="0 0 24 32">
+          <path
+            d="M20.911 5.375l-9.482 9.482 9.482 9.482c0.446 0.446 0.446 1.161 0 1.607l-2.964 2.964c-0.446 0.446-1.161 0.446-1.607 0l-13.25-13.25c-0.446-0.446-0.446-1.161 0-1.607l13.25-13.25c0.446-0.446 1.161-0.446 1.607 0l2.964 2.964c0.446 0.446 0.446 1.161 0 1.607z"
+          />
+        </svg>
+        <svg class="nist-header__logo-image" version="1.1"
+          xmlns="http://www.w3.org/2000/svg" viewBox="-237 385.7 109.7 29.3">
+          <title>National Institute of Standards and Technology</title>
+          <g>
+            <path class="st0"
+              d="M-231,415h-6v-23.1c0,0,0-4.4,4.4-5.8c4-1.3,6.6,1.3,6.6,1.3l19.7,21.3c1,0.6,1.4,0,1.4-0.6v-22h6.1V409
+              c0,1.9-1.6,4.4-4,5.3c-2.4,0.9-4.9,0.9-7.9-1.7l-18.5-20c-0.5-0.5-1.8-0.6-1.8,0.4L-231,415L-231,415z"/>
+            <path class="st0"
+              d="M-195,386.1h6.1v20.7c0,2.2,1.9,2.2,3.6,2.2h26.8c1.1,0,2.4-1.3,2.4-2.7c0-1.4-1.3-2.8-2.5-2.8H-176
+              c-3,0.1-9.2-2.7-9.2-8.5c0-7.1,5.9-8.8,8.6-9h49.4v6.1h-12.3V415h-6v-22.9h-30.2c-2.9-0.2-4.9,4.7-0.2,5.4h18.6
+              c2.8,0,7.4,2.4,7.5,8.4c0,6.1-3.6,9-7.5,9H-185c-4.5,0-6.2-1.1-7.8-2.5c-1.5-1.5-1.7-2.3-2.2-5.3L-195,386.1
+              C-194.9,386.1-195,386.1-195,386.1z"/>
+          </g>
+        </svg>
+      </a>      
+    </header>
+  </div>
+  <details id="sec-notice">
+    <summary>Is this site a preview, demo, mockup or spoof? - <i><b>How you can know</b></i></summary>
+    <p><span>The real site domain ends in <code>nist.gov</code></span>&#xA0;<span>The page address shows <code>https://</code></span></p>
+  </details>
+  <main class="draft">
+    <h1>OSCAL Styler</h1>
+    <p>An XSLT 1.0 workbench set up for <a href="https://pages.nist.gov/OSCAL">OSCAL, the Open Security Controls Assessment Language</a>.</p>
+    <p>Load your OSCAL XML below along with XSLT 1.0 and CSS code. Activate <button onclick="document.getElementById('applyButton').click;">Apply Styles</button> and the loaded data will be transformed (using the XSLT) and rendered (using the CSS). Starter XSLTs for the different OSCAL formats produce a fully functional viewer, ready for the user to enhance and modify; start from scratch; or load your own XSLT to test it. No data is sent to any server.</p>
+    <p>The OSCAL Styler is inspired by M. Honnen's awesome <a href="https://martin-honnen.github.io/xslt3fiddle/">XSLT Fiddle</a> (client-side version), which supports advanced XSLT up to XSLT 3.0/3.1 via the SaxonJS library. See also the spare but impressive <a class="external" href="http://i-like-robots.github.io/xslt-fiddle/">XSLT Fiddle</a> by Github user <tt>i-like-robots</tt>.</p>
+    <p>Feedback on this demonstration is welcome on the public <a class="external" href="https://github.com/usnistgov/xslt-blender/issues">Github Issues</a> board. Or contribute
+      to community discussions in public <a href="https://pages.nist.gov/OSCAL/contact/">OSCAL</a> channels.</p>
+    <details class="boxed"><summary>Load and edit styles</summary>
+    <div class="panels">
+    <details>
+      <summary>XSLT 1.0 <input type="file" accept=".xsl, .xslt" id="loadXSLTButton" name="loadXSLTButton" title="Load OSCAL" onchange="dropFileText(this.files,'XSLTeditbox');this.parentElement.parentElement.open = true;"
+      /><!-- pulldown here for loading -->
+        <button style="float:right" onclick="document.getElementById('XSLTeditbox').value = '';">Clear</button></summary>
+      <textarea id="XSLTeditbox" class="editbox" spellcheck="false" rows="48"></textarea>
+     
+    </details>
+      <div id="applyButtonBox" class="boxed">
+        <button id="applyButton" onclick="applyXSLT(); refreshPageCSS();">Apply&#xA0;Styles</button>
+      </div>
+      
+    <details>
+      <summary>CSS <input type="file" id="loadCSSButton" accept=".css" name="loadCSSButton" title="Load CSS" onchange="dropFileText(this.files,'CSSeditbox');this.parentElement.parentElement.open = true;"
+      />
+        <button style="float:right" onclick="document.getElementById('CSSeditbox').value = '';">Clear</button></summary>
+      <textarea id="CSSeditbox" class="editbox" spellcheck="false" rows="48"></textarea>
+      
+    </details>
+    </div>
+    </details>
+    
+    <button style="float:right" onclick="applyXSLT(); refreshPageCSS();">Apply&#xA0;Styles</button>
+    
+    <details class="boxed" id="loadOSCALpanel">
+      <summary>Load OSCAL <input type="file" id="loadOSCALButton" accept=".xml, .osc, .oscal"  name="loadOSCALButton" title="Load OSCAL"  onchange="loadOSCAL(this.files)" 
+      />
+        <button style="float:right" onclick="clearOSCAL()">Clear OSCAL</button></summary>
+      <div id="OSCALfile">
+        <!-- x -->
+      </div>
+    </details>
+    
+    <div id="displayOSCAL"><!-- --></div>
+    <details class="boxed arrayed">
+      <summary>Who is this for</summary>
+      <ul>
+        <li><a href="https://pages.nist.gov/OSCAL">OSCAL</a> users learning XSLT 1.0 and XPath</li>
+        <li>XSLT and XML practitioners learning <a href="https://pages.nist.gov/OSCAL">OSCAL</a></li>
+        <li>OSCAL developers sketching and testing ideas with real or mock data</li>
+        <li>Any curious students of OSCAL or XSLT</li>
+      </ul>
+      <p>More information on <a class="external" href="https://www.w3.org/TR/xslt-10/">XSLT 1.0</a> may be found on the <a href="https://github.com/usnistgov/xslt-blender/wiki">Project Wiki</a>.</p>
+      
+      <p>This viewer application is maintained on <a class="external" href="https://github.com/usnistgov/xslt-blender/tree/main/sts-viewer">Github, with documentation</a>.</p>
+   </details>
+    <details class="boxed arrayed">
+    <summary>Is this site a demonstration, a service or both?</summary>
+      <p>This application is provided by NIST as an educational demonstration of how a service can be created, not as a fully operational service.</p>
+      <p>No guarantees or warranties are provided by NIST that the demo service will be maintained, updated, upgraded, or always available. While NIST intends to keep the demonstration running (with <a class="external" href="https://github.com/usnistgov/xslt-blender">project source code</a> available), NIST also reserves the right to stop supporting it, or to remove or rework it, without any prior warning.</p>
+      <p>The best way to ensure access to the application over the long term is to replicate it. See the <a class="external" href="https://github.com/usnistgov/xslt-blender/wiki/Maintenance-and-Support">project wiki page on Maintenance and Support</a> for more details on how these projects are designed to be standards-based, accessible, portable, adaptable over time and unhindered by practical impediments to wide deployment, either technical or legal.</p></details>
+  </main>
+  <div class="project-footer">
+    <p><i>OSCAL Styler</i> is an <a  href="https://pages.nist.gov/xslt-blender">XSLT Blender</a> project using XSLT 1.0 capabilities built into your browser, with no external dependencies.</p>
+    <p>Disclaimers apply; no warranty should or can be assumed.</p>
+    <p>See the code and contact the developers in the <a class="external" 
+      href="https://github.com/usnistgov/xslt-blender">project repository</a>.</p>
+  </div>
+  <div id="nistfootergoeshere"><footer class="nist-footer">
+    <div class="nist-footer__inner">
+      <div class="nist-footer__menu" role="navigation">
+        <ul>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/privacy-policy">Site Privacy</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/oism/accessibility">Accessibility</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/privacy">Privacy Program</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/oism/copyrights">Copyrights</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.commerce.gov/vulnerability-disclosure-policy">Vulnerability Disclosure</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/no-fear-act-policy">No Fear Act Policy</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/foia">FOIA</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/environmental-policy-statement">Environmental Policy</a>
+          </li>
+          <li class="nist-footer__menu-item ">
+            <a href="https://www.nist.gov/summary-report-scientific-integrity">Scientific Integrity</a>
+          </li>
+          <li class="nist-footer__menu-item ">
+            <a href="https://www.nist.gov/nist-information-quality-standards">Information Quality Standards</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.commerce.gov/">Commerce.gov</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.science.gov/">Science.gov</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.usa.gov/">USA.gov</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://vote.gov/">Vote.gov</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="nist-footer__logo">
+      <a href="https://www.nist.gov/" title="National Institute of Standards and Technology" class="nist-footer__logo-link" rel="home">
+        <img src="https://pages.nist.gov/nist-header-footer/images/nist_logo_brand_white.svg" alt="National Institute of Standards and Technology logo"/>
+      </a>
+    </div>
+  </footer>
+  </div>
+  
+  </body>
+</html>

--- a/oscal-styler/index.html
+++ b/oscal-styler/index.html
@@ -45,121 +45,100 @@ div.unknown * { margin: 0em}
   <!-- Google analytics    -->
   <script async="async" type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NIST&subagency=github&pua=UA-66610693-1&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c">
 </script>
-  <script type="module">
-      import { fileXMLContent, spliceIntoPage, xsltEngineForHREF, parseXMLLiteral } from "../lib/xslt-blender.js";
-      // import { setupXSLTEngine } from "../lib/xslt-blender.js";
+<script type="module">
+    import { fileXMLContent, spliceIntoPage, xsltEngineForHREF, parseXMLLiteral } from "../lib/xslt-blender.js";
 
-      // todo: replace with something a little less cumbersome?
-      window.fileXMLContent = fileXMLContent;
-      window.spliceIntoPage = spliceIntoPage;
-      // window.parseAndTransformXMLLiteral = parseAndTransformXMLLiteral;
-      window.xsltEngineForHREF = xsltEngineForHREF;
-      window.parseXMLLiteral = parseXMLLiteral;
-      // window.setupXSLTEngine = setupXSLTEngine
+    // todo: replace with something a little less cumbersome?
+    window.fileXMLContent = fileXMLContent;
+    window.spliceIntoPage = spliceIntoPage;
+    window.xsltEngineForHREF = xsltEngineForHREF;
+    window.parseXMLLiteral = parseXMLLiteral;
 
-  </script>
+</script>
    
-   <script type="text/javascript">
+<script type="text/javascript">
      
     let loadedOSCAL = new Document();
 
-    // const showLoadXSLTEngine = new XSLTProcessor();
-    // showLoadXSLTEngine = await xsltEngineForHREF('show-loaded-xml.xsl');
-    
     async function loadOSCAL(fileSet) {
       const viewerXSLTEngine = await xsltEngineForHREF('show-loaded-xml.xsl');
-          
       for (const eachFile of fileSet) {
         const anXML = await fileXMLContent(eachFile);
         if (anXML) {
+          const resultDocument = viewerXSLTEngine.transformToDocument(anXML);
           loadedOSCAL = anXML;
-
-          const resultDocument = viewerXSLTEngine.transformToDocument(loadedOSCAL);
-
           spliceIntoPage('OSCALfile', resultDocument, true);
-          document.getElementById('loadOSCALpanel').open = true;
         }
-      }
-    }
-    
-    function dropFileText(fileSet,whereID) {
-      for (const eachFile of fileSet) {
-        let where = document.getElementById(whereID)
-        let frdr = new FileReader();
-        frdr.onload = function () {
-          where.value = frdr.result
-        }
-        frdr.readAsText(eachFile);
       }
     }
    
     const clearLoad = (loadButtonID, clearDivID) => {
       const clearing = document.getElementById(clearDivID);
-      // clearing.closest("details").open = false; // close the ancestor details
-      let emptyList = new DataTransfer();
-      let noFiles = emptyList.files;
-      if (clearing.value) { clearing.value =  '' };
-      while ( clearing.firstChild && clearing.removeChild(clearing.firstChild) );
+      const emptyList = new DataTransfer();
+      const noFiles = emptyList.files;
+      if (clearing.value) { clearing.value = '' };
+      clearing.replaceChildren();
       document.getElementById(loadButtonID).files = noFiles;
     }
 
     function clearDisplay() {
-      document.getElementById('displayFrame').contentDocument.body.replaceChildren()
+      document.getElementById('displayFrame').contentDocument.body.replaceChildren();
     }
-   
-    function refreshPageCSS()  { 
+
+    function refreshPageCSS() {
       const userCSS = document.getElementById('CSSeditbox').value;
       const frameDocument = document.getElementById('displayFrame').contentDocument;
       const newStyle = frameDocument.createElement('style');
-      newStyle.setAttribute('id','userCSS');
+      newStyle.setAttribute('id', 'userCSS');
       newStyle.append(userCSS);
       frameDocument.getElementById('userCSS')?.remove();
       frameDocument.head.append(newStyle);
-      // while (frameDocument.body.firstChild && frameDocument.body.removeChild(frameDocument.body.firstChild));
-      //        return frameDocument.body.append(transformResult);
-      //  return true      
-
-     }
-
-    async function applyXSLT() {
-        // const OSCALloadButton = document.getElementById('loadOSCALButton');
-        // const loadedOSCAL = await fileXMLContent(OSCALloadButton.files[0]);
-        const XSLTLiteral = document.getElementById('XSLTeditbox').value;
-        // console.log(XSLTLiteral);
-        if (!loadedOSCAL) { alert('Please load your OSCAL XML document'); }
-        else {
-          const OSCALxml = loadedOSCAL;
-          const ViewerXSLT = parseXMLLiteral(XSLTLiteral);
-          const errorNode = ViewerXSLT.querySelector("parsererror");
-
-          if (errorNode) {  alert("XSLT Stylesheet does not parse") }
-          else { 
-            const xsltEngine = new XSLTProcessor();
-            try {
-              xsltEngine.importStylesheet(ViewerXSLT);
-              const frameDocument = document.getElementById('displayFrame').contentDocument;
-              const transformResult = xsltEngine.transformToFragment(loadedOSCAL, frameDocument);
-              frameDocument.body.replaceChildren();
-              // while (frameDocument.body.firstChild && frameDocument.body.removeChild(frameDocument.body.firstChild));
-              return frameDocument.body.append(transformResult);
-              // if (resultDocument) { return spliceIntoPage('displayOSCAL', resultDocument, true); }
-              // return .body.append(resultDocument);
-            } catch(e) { alert("Failure applying XSLT 1.0" ); console.log(e); }
-          }
-        }
     }
 
-    
+    // graps text contents of XSLTeditbox and does its best to apply it to the currently loaded document
+    async function applyXSLT() {
+      const XSLTLiteral = document.getElementById('XSLTeditbox').value;
+      if (!loadedOSCAL) { alert('Please load your OSCAL XML document'); }
+      else {
+        const OSCALxml = loadedOSCAL;
+        const ViewerXSLT = parseXMLLiteral(XSLTLiteral);
+        const errorNode = ViewerXSLT.querySelector("parsererror");
+        if (errorNode) { alert("XSLT Stylesheet does not parse") }
+        else {
+          const xsltEngine = new XSLTProcessor();
+          try {
+            xsltEngine.importStylesheet(ViewerXSLT);
+            const frameDocument = document.getElementById('displayFrame').contentDocument;
+            const transformResult = xsltEngine.transformToFragment(loadedOSCAL, frameDocument);
+            frameDocument.body.replaceChildren(); // clears the body
+            return frameDocument.body.append(transformResult);
+          } catch (e) { alert("Failure applying XSLT 1.0"); console.log(e); }
+        }
+      }
+    }
+
+    // provided a fileList object by a UI button, pastes its file contents into a textarea
+    // does not defend against multiple files
+    function dropFileText(fileSet, textareaID) {
+      for (const eachFile of fileSet) {
+        let theTextArea = document.getElementById(textareaID)
+        let frdr = new FileReader();
+        frdr.onload = () => theTextArea.value = frdr.result;
+        frdr.readAsText(eachFile);
+      }
+    }
+
     // mainly cribbed from https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Fetching_data
-    function acquireXSLT(HREF,targetID) { 
-        const target = document.getElementById(targetID);
-        fetch(HREF) // returns a promise
-        .then((response) => {
-            if (!response.ok) {  throw new Error(`HTTP error: ${response.status}`); }
-            return response.text();
-        })
-        .then((text) => { target.value = text;  })
-        .catch((error) => { console.log = `Could not fetch XSLT from ${HREF}: ${error}`; }
+    // grabs  file text contents and drops it into the textarea designated
+    function pasteFileContents(HREF, textareaID) {
+      const theTextArea = document.getElementById(textareaID);
+      fetch(HREF) // returns a promise
+        .then( (response) => {
+          if (!response.ok) { throw new Error(`HTTP error: ${response.status}`); }
+          return response.text();
+        } )
+        .then( (text) => { theTextArea.value = text; } )
+        .catch( (error) => { console.log = `Could not fetch XSLT from ${HREF}: ${error}`; }
         );
     }
 
@@ -205,13 +184,13 @@ div.unknown * { margin: 0em}
   <main class="draft">
     <h1>OSCAL Styler</h1>
     <p>An XSLT 1.0 workbench set up for <a href="https://pages.nist.gov/OSCAL">OSCAL, the Open Security Controls Assessment Language</a>.</p>
-    <p>Load your OSCAL XML below along with XSLT 1.0 and CSS code. Activate <button onclick="document.getElementById('applyButton').click;">Apply Styles</button> and the loaded data will be transformed using the XSLT and rendered on the page using the CSS. Load your own XSLT to test it, or (soon) load a pre-made XSLT and enhance and modify it in the page, applying it to see the results dynamically. No data is sent to any server.</p>
+    <p>Load your OSCAL XML below along with XSLT 1.0 and CSS code. Activate <button onclick="document.getElementById('applyButton').click;">Apply Styles</button> and the loaded data will be transformed using the XSLT and rendered on the page using the CSS. Load your own XSLT to test it, or load a ready-made basic XSLT and enhance and modify it in the page, applying it to see the results dynamically. No data is sent to any server.</p>
     <p>The OSCAL Styler is inspired by M. Honnen's awesome <a href="https://martin-honnen.github.io/xslt3fiddle/">XSLT Fiddle</a> (client-side version), which supports advanced XSLT up to XSLT 3.0/3.1 via the SaxonJS library. See also the spare but impressive <a class="external" href="http://i-like-robots.github.io/xslt-fiddle/">XSLT Fiddle</a> by Github user <tt>i-like-robots</tt>.</p>
     <p>Feedback on this demonstration is welcome on the public <a class="external" href="https://github.com/usnistgov/xslt-blender/issues">Github Issues</a> board. Or contribute
       to community discussions in public <a href="https://pages.nist.gov/OSCAL/contact/">OSCAL</a> channels.</p>
 
       <details class="boxed" id="loadOSCALpanel">
-        <summary>Load OSCAL <input type="file" id="loadOSCALButton" accept=".xml, .osc, .oscal"  name="loadOSCALButton" title="Load OSCAL"  onchange="loadOSCAL(this.files)" 
+        <summary>Load OSCAL <input type="file" id="loadOSCALButton" accept=".xml, .osc, .oscal"  name="loadOSCALButton" title="Load OSCAL"  onchange="loadOSCAL(this.files); this.closest('details').open = true;" 
         />
           <button style="float:right" onclick="loadedOSCAL = undefined; clearLoad('loadOSCALButton','OSCALfile');">Clear OSCAL</button></summary>
         <div id="OSCALfile">
@@ -229,7 +208,7 @@ div.unknown * { margin: 0em}
     <div class="codePanel">
       <p>XSLT 1.0 <input type="file" accept=".xsl, .xslt" id="loadXSLTButton" name="loadXSLTButton" title="Load OSCAL" onchange="dropFileText(this.files,'XSLTeditbox');this.parentElement.parentElement.open = true;"
       /><!-- pulldown here for loading -->
-        <button class="floatButton" onclick="acquireXSLT('oscal-basic-display.xsl','XSLTeditbox');">Load starter OSCAL XSLT 1.0</button>
+        <button class="floatButton" onclick="pasteFileContents('oscal-basic-display.xsl','XSLTeditbox');">Load starter OSCAL XSLT 1.0</button>
         <button class="floatButton" onclick="clearLoad('loadXSLTButton','XSLTeditbox');">Clear</button></p>
       <textarea id="XSLTeditbox" class="editbox" spellcheck="false" rows="48"></textarea>
      
@@ -261,7 +240,7 @@ div.unknown * { margin: 0em}
       
       <p>This viewer application is maintained on <a class="external" href="https://github.com/usnistgov/xslt-blender/tree/main/sts-viewer">Github, with documentation</a>.</p>
    </details>
-    <details class="boxed arrayed">
+   <details class="boxed arrayed">
     <summary>Is this site a demonstration, a service or both?</summary>
       <p>This application is provided by NIST as an educational demonstration of how a service can be created, not as a fully operational service.</p>
       <p>No guarantees or warranties are provided by NIST that the demo service will be maintained, updated, upgraded, or always available. While NIST intends to keep the demonstration running (with <a class="external" href="https://github.com/usnistgov/xslt-blender">project source code</a> available), NIST also reserves the right to stop supporting it, or to remove or rework it, without any prior warning.</p>

--- a/oscal-styler/oscal-basic-display.xsl
+++ b/oscal-styler/oscal-basic-display.xsl
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+  xmlns="http://www.w3.org/1999/xhtml" xmlns:oscal="http://csrc.nist.gov/ns/oscal/1.0">
+
+  <xsl:template match="/">
+    <html>
+      <head>
+        <xsl:apply-templates select="descendant::oscal:title[1]" mode="title"/>
+        <style type="text/css">
+
+.control { margin:1em; padding: 1em; border: thin dotted black }
+.control > *:first-child { margin-top: 0em }
+
+h1, h2, h3, h4, h5, h6 { font-family: sans-serif }
+h3 { font-size: 120% }
+
+div, section { border-left: thin solid black; padding-left: 0.5em; margin-left: 0.5em }
+
+section h3     { font-size: 160% }
+section h3     { font-size: 140% }
+div h3         { font-size: 130% }
+div div h3     { font-size: 120% }
+div div div h3 { font-size: 110% }
+
+.param { font-style: italic }
+.insert, .choice { border: thin solid black; padding: 0.1em }
+
+.subst  { color: midnightblue; font-family: sans-serif; font-sizea; 85% } 
+
+.param .em { font-style: roman }
+
+        </style>
+      </head>
+      <body>
+        <xsl:apply-templates/>
+      </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template match="oscal:catalog">
+    <div class="catalog">
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="oscal:title">
+    <h2 class="title">
+      <xsl:apply-templates/>
+    </h2>
+  </xsl:template>
+
+  <xsl:template match="oscal:title" mode="title">
+    <xsl:value-of select="."/>
+  </xsl:template>
+
+
+  <xsl:template match="oscal:group">
+    <section class="group">
+      <xsl:apply-templates/>
+    </section>
+  </xsl:template>
+
+  <!--<xsl:key name="declarations" match="oscal:control-spec" use="@type"/>
+  
+  <xsl:key name="declarations" match="oscal:property | oscal:statement | oscal:parameter"
+    use="concat(@context,'#',@role)"/>-->
+
+  <xsl:key name="assignment" match="oscal:param" use="@id"/>
+
+  <xsl:template match="oscal:control | oscal:subcontrol | oscal:component | oscal:part">
+    <div class="{local-name()} {@class}">
+      <xsl:copy-of select="@id"/>
+      <xsl:call-template name="make-title">
+        <xsl:with-param name="runins" select="oscal:prop[@class = 'name']"/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+
+  <!-- Picked up in parent -->
+  <xsl:template match="oscal:control/oscal:title"/>
+
+  <xsl:template name="make-title">
+    <xsl:param name="runins" select="/.."/>
+    <h3>
+      <xsl:apply-templates select="$runins" mode="run-in"/>
+      <xsl:for-each select="@class">
+        <xsl:text>[</xsl:text>
+        <xsl:value-of select="."/>
+        <xsl:text>] </xsl:text>
+      </xsl:for-each>
+
+      <xsl:for-each select="oscal:title">
+        <xsl:apply-templates/>
+      </xsl:for-each>
+    </h3>
+  </xsl:template>
+
+  <xsl:template match="oscal:prop" mode="run-in">
+    <span class="run-in subst">
+      <xsl:apply-templates/>
+    </span>
+    <xsl:text> </xsl:text>
+  </xsl:template>
+
+  <xsl:template match="oscal:param">
+    <p class="param">
+      <span class="subst">
+        <xsl:for-each select="@id">
+          <xsl:value-of select="."/>
+        </xsl:for-each>
+        <xsl:text>: </xsl:text>
+      </span>
+      <xsl:apply-templates/>
+    </p>
+
+  </xsl:template>
+
+  <xsl:template match="oscal:prop">
+    <p class="prop {@name}">
+      <span class="subst">
+        <xsl:apply-templates select="." mode="title"/>
+        <xsl:text>: </xsl:text>
+      </span>
+      <xsl:apply-templates select="@value"/>
+    </p>
+  </xsl:template>
+
+  <xsl:template match="*" mode="title">
+    <xsl:value-of select="@class"/>
+  </xsl:template>
+
+  <xsl:template match="oscal:p">
+    <p class="p">
+      <xsl:apply-templates/>
+    </p>
+  </xsl:template>
+
+  <xsl:template match="oscal:insert">
+    <xsl:variable name="param-id" select="@param-id"/>
+    <xsl:variable name="closest-param"
+      select="ancestor-or-self::*/oscal:param[@id = $param-id][last()]"/>
+    <!-- Providing substitution via declaration not yet supported -->
+    <span class="insert">
+      <xsl:for-each select="$closest-param">
+        <span class="subst">
+          <xsl:apply-templates/>
+        </span>
+      </xsl:for-each>
+      <xsl:if test="not($closest-param)">
+        <xsl:apply-templates/>
+      </xsl:if>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="oscal:ol">
+    <ol class="ol">
+      <xsl:apply-templates/>
+    </ol>
+  </xsl:template>
+  <xsl:template match="oscal:li">
+    <li class="li">
+      <xsl:apply-templates/>
+    </li>
+  </xsl:template>
+
+  <!-- only handles some kinds of links, and not yet fetching value from link targets -->
+  <xsl:template match="oscal:link">
+    <p class="link">
+      <a class="xref">
+        <xsl:copy-of select="@href"/>
+        <xsl:apply-templates/>
+      </a>
+    </p>
+  </xsl:template>
+
+  <xsl:template match="oscal:ref">
+    <div class="ref">
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="oscal:em | oscal:i | oscal:b | oscal:strong | oscal:code | oscal:q">
+    <xsl:element name="{ local-name()}">
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="oscal:citation">
+    <p class="citation">
+      <xsl:apply-templates/>
+    </p>
+  </xsl:template>
+
+
+
+</xsl:stylesheet>

--- a/oscal-styler/oscal-html-port.xsl
+++ b/oscal-styler/oscal-html-port.xsl
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+  xmlns="http://www.w3.org/1999/xhtml" xmlns:oscal="http://csrc.nist.gov/ns/oscal/1.0">
+
+  <xsl:template match="*">
+    <xsl:call-template name="port"/>
+  </xsl:template>
+  
+  <xsl:template name="port">
+    <xsl:element name="oscal-{ local-name() }" namespace="http://www.w3.org/1999/xhtml">
+      <xsl:apply-templates select="attribute::*"/>
+      <xsl:attribute name="class">
+        <xsl:value-of select="local-name()"/>
+      </xsl:attribute>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+  
+  <xsl:template match="@*">
+    <xsl:attribute name="data-{ local-name() }">
+      <xsl:value-of select="."/>
+    </xsl:attribute>
+  </xsl:template>
+  
+  <xsl:template match="oscal:prop">
+    <oscal-prop>
+      <xsl:apply-templates select="attribute::*"/>
+      <!-- forcing this to appear after attributes -->
+      <xsl:for-each select="@value">
+        <oscal-value>
+          <xsl:value-of select="."/>
+        </oscal-value>
+      </xsl:for-each>
+      <xsl:apply-templates/>
+    </oscal-prop>
+  </xsl:template>
+  
+  <xsl:template match="oscal:p | oscal:table | oscal:pre | oscal:ul | oscal:ol |
+    oscal:p//* | oscal:table//* | oscal:pre//* | oscal:ul//* | oscal:ol//*">
+      <xsl:element name="{ local-name() }" namespace="http://www.w3.org/1999/xhtml">
+        <xsl:copy-of select="attribute::*"/>
+        <xsl:apply-templates/>
+      </xsl:element>
+  </xsl:template>
+  
+  <xsl:template match="oscal:insert" priority="101">
+    <ins>
+      <xsl:apply-templates select="@*"/>
+      <xsl:value-of select="@id-ref"/>
+      <!-- traversal to retrieve parameter value or label can go here -->
+    </ins>
+  </xsl:template>
+    
+</xsl:stylesheet>

--- a/oscal-styler/oscal-html-port.xsl
+++ b/oscal-styler/oscal-html-port.xsl
@@ -2,6 +2,12 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
   xmlns="http://www.w3.org/1999/xhtml" xmlns:oscal="http://csrc.nist.gov/ns/oscal/1.0">
 
+  <xsl:template match="/">
+    <main class="oscal-port">
+      <xsl:apply-templates/>
+    </main>
+  </xsl:template>
+
   <xsl:template match="*">
     <xsl:call-template name="port"/>
   </xsl:template>
@@ -22,6 +28,20 @@
     </xsl:attribute>
   </xsl:template>
   
+  <xsl:template match="@id">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+  
+  <xsl:template match="@uuid">
+    <xsl:attribute name="data-{ local-name() }">
+      <xsl:value-of select="."/>
+    </xsl:attribute>
+    <xsl:attribute name="id">
+      <xsl:text>uuid_</xsl:text>
+      <xsl:value-of select="."/>
+    </xsl:attribute>
+  </xsl:template>
+  
   <xsl:template match="oscal:prop">
     <oscal-prop>
       <xsl:apply-templates select="attribute::*"/>
@@ -36,7 +56,8 @@
   </xsl:template>
   
   <xsl:template match="oscal:p | oscal:table | oscal:pre | oscal:ul | oscal:ol |
-    oscal:p//* | oscal:table//* | oscal:pre//* | oscal:ul//* | oscal:ol//*">
+    oscal:p//* | oscal:table//* | oscal:pre//* | oscal:ul//* | oscal:ol//* |
+    oscal:i | oscal:em | oscal:strong | oscal:b | oscal:q | oscal:a | oscal:code | oscal:img | oscal:sub | oscal:sup" >
       <xsl:element name="{ local-name() }" namespace="http://www.w3.org/1999/xhtml">
         <xsl:copy-of select="attribute::*"/>
         <xsl:apply-templates/>

--- a/oscal-styler/oscal-port-html.css
+++ b/oscal-styler/oscal-port-html.css
@@ -1,0 +1,21 @@
+/* Some basic CSS demonstrating how to apply rules to OSCAL as represented in an HTML DOM
+   as delivered by oscal-html-port.xsl */
+
+style { display: none }
+
+body { background-color: lemonchiffon }
+
+* { display: block }
+
+p *, li *, td * { display: inline }
+i, em, b, strong, q, code, img, sub, sup { display: inline }
+
+/* in the DOM, OSCAL will be represented by `oscal-` prefixes on element names
+   classes are *also* assigned */
+
+oscal-control { padding: 0.5em; border: thin dotted black; margin-top: 0.5em }
+
+oscal-control > .title { font-size:120%; font-weight: bold }
+
+oscal-metadata *:before { content: attr(class) ": " }
+

--- a/oscal-styler/painter.html
+++ b/oscal-styler/painter.html
@@ -216,7 +216,7 @@ div.unknown * { margin: 0em}
     <div class="codePanel">
       <p>CSS <input type="file" id="loadCSSButton" accept=".css" name="loadCSSButton" title="Load CSS" onchange="dropFileText(this.files,'CSSeditbox');this.parentElement.parentElement.open = true;"
       />
-      <button class="floatButton" onclick="pasteFileContents('oscal-port.css','CSSeditbox');">Load starter CSS</button>
+      <button class="floatButton" onclick="pasteFileContents('oscal-port-html.css','CSSeditbox');">Load starter CSS</button>
       <button class="clearButton floatButton" onclick="clearAll();">Clear All</button>
       <button class="floatButton" onclick="clearLoad('loadCSSButton','CSSeditbox');">Clear</button></p>
       <textarea id="CSSeditbox" class="editbox" spellcheck="false" rows="12">/* an illustration */
@@ -232,7 +232,7 @@ body { background-color: lemonchiffon }
 p *, li *, td * { display: inline }
 i, em, b, strong, q, code, img, sub, sup { display: inline }
 
-/* in the DOM, oscal will be represented by `oscal-` prefixes on element names
+/* in the DOM, OSCAL will be represented by `oscal-` prefixes on element names
    classes are *also* assigned */
 
 oscal-control { padding: 0.5em; border: thin dotted black; margin-top: 0.5em }

--- a/oscal-styler/painter.html
+++ b/oscal-styler/painter.html
@@ -4,9 +4,14 @@
 <head>
   <title>OSCAL Painter</title>
   <meta charset="utf-8" />
+  <link rel="stylesheet" href="../nist-boilerplate.css" type="text/css" />
+  <link rel="stylesheet" href="../nist-combined.css"/>
+  
   <style type="text/css" xml:space="preserve" id="pageStyle">
 
 body { background-color: mintcream }
+
+details#sec-notice { background-color: lightsteelblue;  border-bottom: thin solid black }
 
 .panels {
   margin-top: 0.6em;
@@ -31,10 +36,7 @@ div.unknown * { margin: 0em}
 
 #displayFrame { width: 100%; height: 62vh; resize: both; overflow: auto; }
 
-
   </style>
-  <link rel="stylesheet" href="../nist-boilerplate.css" type="text/css" />
-  <link rel="stylesheet" href="../nist-combined.css"/>
   <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script type="text/javascript" id="MathJax-script" async="async"
   src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
@@ -191,9 +193,9 @@ div.unknown * { margin: 0em}
   <main class="draft">
     <h1>OSCAL Painter</h1>
     <p>Try out your own CSS formatting on your own OSCAL.</p>
-    <p>Based on the <a href="index.html">OSCAL Styler</a>, this page lets you load your <a href="https://pages.nist.gov/OSCAL">OSCAL</a> data and style it dynamically with your own CSS. No data is sent to any server.</p>
+    <p>Based on the <a href="index.html">OSCAL Styler</a>, this page can be loaded with your <a href="https://pages.nist.gov/OSCAL">OSCAL</a> data and styled dynamically, with typography, layout, font settings and colors provided with your own CSS. No data is sent to any server.</p>
     <p>The OSCAL Painter offers a <q>play set</q> of tools for users to explore the OSCAL data model and how it can be handled in a browser via an HTML surrogate. This HTML is produced by application of a generalized stylesheet, which casts OSCAL data into an isomorphic, equivalent and traceable form of HTML. To see the HTML model, load OSCAL XML and use your web developer tools to examine the result of this transformation as it populates the page. With CSS styling applied to the HTML, a web designer can provide the view with sophisticated styling, providing a customized or branded <q>look and feel</q>.</p>
-    <a>If the mapping from OSCAL into an HTML surrogate must be adapted, an application like one demonstrated by the <a href="index.html">OSCAL Styler</a> comes into play. <i>Expert tip:</i> <a href="https://www.w3.org/TR/xml-stylesheet/" class="external">CSS can be applied directly to XML</a> even without an intervening HTML conversion.</p>
+    <a>If the mapping from OSCAL into an HTML surrogate must be adapted, an application like one demonstrated by the <a href="index.html">OSCAL Styler</a> comes into play. <b>Pro tip:</b> <a href="https://www.w3.org/TR/xml-stylesheet/" class="external">CSS can be applied directly to XML in your browser</a> even without an intervening HTML conversion, or this page.</p>
     <p>Feedback on this demonstration is welcome on the public <a class="external" href="https://github.com/usnistgov/xslt-blender/issues">Github Issues</a> board. Or contribute
       to community discussions in public <a href="https://pages.nist.gov/OSCAL/contact/">OSCAL</a> channels.</p>
 

--- a/oscal-styler/painter.html
+++ b/oscal-styler/painter.html
@@ -29,7 +29,7 @@ div.unknown * { margin: 0em}
 
 .floatButton { float:right; margin-left: 0.6em }
 
-#displayFrame { width: 100%; height: 62vh }
+#displayFrame { width: 100%; height: 62vh; resize: both; overflow: auto; }
 
 
   </style>
@@ -197,7 +197,7 @@ div.unknown * { margin: 0em}
       to community discussions in public <a href="https://pages.nist.gov/OSCAL/contact/">OSCAL</a> channels.</p>
 
       <details class="boxed" id="loadOSCALpanel">
-        <summary>Load OSCAL <input type="file" id="loadOSCALButton" accept=".xml, .osc, .oscal"  name="loadOSCALButton" title="Load OSCAL"  onchange="loadOSCAL(this.files); this.closest('details').open = true;" 
+        <summary>Load OSCAL XML <input type="file" id="loadOSCALButton" accept=".xml, .osc, .oscal"  name="loadOSCALButton" title="Load OSCAL"  onchange="loadOSCAL(this.files); this.closest('details').open = true;" 
         />
           <button style="float:right" onclick="loadedOSCAL = undefined; clearLoad('loadOSCALButton','OSCALfile');">Clear OSCAL</button></summary>
         <div id="OSCALfile">
@@ -216,9 +216,32 @@ div.unknown * { margin: 0em}
     <div class="codePanel">
       <p>CSS <input type="file" id="loadCSSButton" accept=".css" name="loadCSSButton" title="Load CSS" onchange="dropFileText(this.files,'CSSeditbox');this.parentElement.parentElement.open = true;"
       />
+      <button class="floatButton" onclick="pasteFileContents('oscal-port.css','CSSeditbox');">Load starter CSS</button>
       <button class="clearButton floatButton" onclick="clearAll();">Clear All</button>
       <button class="floatButton" onclick="clearLoad('loadCSSButton','CSSeditbox');">Clear</button></p>
-      <textarea id="CSSeditbox" class="editbox" spellcheck="false" rows="12">body { background-color: white }</textarea>
+      <textarea id="CSSeditbox" class="editbox" spellcheck="false" rows="12">/* an illustration */
+/* Some basic CSS demonstrating how to apply rules to OSCAL as represented in an HTML DOM
+as delivered by oscal-html-port.xsl */
+
+style { display: none }
+
+body { background-color: lemonchiffon }
+
+* { display: block }
+
+p *, li *, td * { display: inline }
+i, em, b, strong, q, code, img, sub, sup { display: inline }
+
+/* in the DOM, oscal will be represented by `oscal-` prefixes on element names
+   classes are *also* assigned */
+
+oscal-control { padding: 0.5em; border: thin dotted black; margin-top: 0.5em }
+
+oscal-control > .title { font-size:120%; font-weight: bold }
+
+oscal-metadata *:before { content: attr(class) ": " }
+     
+</textarea>
       
     </div>
     </div>

--- a/oscal-styler/painter.html
+++ b/oscal-styler/painter.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+
+<head>
+  <title>OSCAL Painter</title>
+  <meta charset="utf-8" />
+  <style type="text/css" xml:space="preserve" id="pageStyle">
+
+body { background-color: whitesmoke }
+
+.panels {
+  margin-top: 0.6em;
+  }
+  
+.panels > * { vertical-align: text-top; outline: thin solid black; padding: 0.4em; margin: 0.25em 0em;
+  background-color: whitesmoke }
+
+.boxed.fullwidth { width: 100% }
+
+div.oscal { padding: 0.6em; outline: medium inset forestgreen; background-color: lightgreen }
+div.oscal * { margin: 0em}
+
+div.unknown { padding: 0.6em; outline: medium inset red; background-color: pink }
+div.unknown * { margin: 0em}
+
+.editbox { width: 100%; box-sizing: border-box; resize: both; }
+
+.codePanel { min-width: 30vw}
+
+.floatButton { float:right; margin-left: 0.6em }
+
+#displayFrame { width: 100%; height: 62vh }
+
+
+  </style>
+  <link rel="stylesheet" href="../nist-boilerplate.css" type="text/css" />
+  <link rel="stylesheet" href="../nist-combined.css"/>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script type="text/javascript" id="MathJax-script" async="async"
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+</script>
+  <!-- https://github.com/usnistgov/pages-root/wiki/Adding-NIST-required-branding-and-features-to-your-site -->
+  <!-- Google analytics    -->
+  <script async="async" type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NIST&subagency=github&pua=UA-66610693-1&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c">
+</script>
+<script type="module">
+    import { fileXMLContent, spliceIntoPage, xsltEngineForHREF, parseXMLLiteral } from "../lib/xslt-blender.js";
+
+    // todo: replace with something a little less cumbersome?
+    window.fileXMLContent = fileXMLContent;
+    window.spliceIntoPage = spliceIntoPage;
+    window.xsltEngineForHREF = xsltEngineForHREF;
+    window.parseXMLLiteral = parseXMLLiteral;
+
+</script>
+   
+<script type="text/javascript">
+     
+    let loadedOSCAL = new Document();
+
+    async function loadOSCAL(fileSet) {
+      const viewerXSLTEngine = await xsltEngineForHREF('show-loaded-xml.xsl');
+      for (const eachFile of fileSet) {
+        const anXML = await fileXMLContent(eachFile);
+        if (anXML) {
+          const resultDocument = viewerXSLTEngine.transformToDocument(anXML);
+          loadedOSCAL = anXML;
+          spliceIntoPage('OSCALfile', resultDocument, true);
+        }
+      }
+    }
+   
+    const clearLoad = (loadButtonID, clearDivID) => {
+      const clearing = document.getElementById(clearDivID);
+      const emptyList = new DataTransfer();
+      const noFiles = emptyList.files;
+      if (clearing.value) { clearing.value = '' };
+      clearing.replaceChildren();
+      document.getElementById(loadButtonID).files = noFiles;
+    }
+
+    function clearDisplay() {
+      document.getElementById('displayFrame').contentDocument.body.replaceChildren();
+    }
+
+    function clearAll() {
+      clearDisplay();
+      clearLoad('loadOSCALButton','OSCALfile');
+      clearLoad('loadCSSButton','CSSeditbox');
+      loadedOSCAL = undefined;
+    }
+
+    function refreshPageCSS() {
+      const userCSS = document.getElementById('CSSeditbox').value;
+      const frameDocument = document.getElementById('displayFrame').contentDocument;
+      const newStyle = frameDocument.createElement('style');
+      newStyle.setAttribute('id', 'userCSS');
+      newStyle.append(userCSS);
+      frameDocument.getElementById('userCSS')?.remove();
+      frameDocument.head.append(newStyle);
+    }
+
+    // graps text contents of XSLTeditbox and does its best to apply it to the currently loaded document
+    async function applyXSLT() {
+      // const XSLTLiteral = document.getElementById('XSLTeditbox').value;
+      const xsltEngine = await xsltEngineForHREF('oscal-html-port.xsl');
+
+      if (!loadedOSCAL) { alert('Please load your OSCAL XML document'); }
+      else {
+        const OSCALxml = loadedOSCAL;
+        // const ViewerXSLT = parseXMLLiteral(XSLTLiteral);
+        // const errorNode = ViewerXSLT.querySelector("parsererror");
+        //if (errorNode) { alert("XSLT Stylesheet does not parse") }
+        //else {
+        //  const xsltEngine = new XSLTProcessor();
+          try {
+            // xsltEngine.importStylesheet(ViewerXSLT);
+            const frameDocument = document.getElementById('displayFrame').contentDocument;
+            const transformResult = xsltEngine.transformToFragment(loadedOSCAL, frameDocument);
+            frameDocument.body.replaceChildren(); // clears the body
+            return frameDocument.body.append(transformResult);
+          } catch (e) { alert("Failure applying XSLT 1.0"); console.log(e); }
+        // }
+      }
+    }
+
+    // provided a fileList object by a UI button, pastes its file contents into a textarea
+    // does not defend against multiple files
+    function dropFileText(fileSet, textareaID) {
+      for (const eachFile of fileSet) {
+        let theTextArea = document.getElementById(textareaID)
+        let frdr = new FileReader();
+        frdr.onload = () => theTextArea.value = frdr.result;
+        frdr.readAsText(eachFile);
+      }
+    }
+
+    // mainly cribbed from https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Fetching_data
+    // grabs  file text contents and drops it into the textarea designated
+    function pasteFileContents(HREF, textareaID) {
+      const theTextArea = document.getElementById(textareaID);
+      fetch(HREF) // returns a promise
+        .then( (response) => {
+          if (!response.ok) { throw new Error(`HTTP error: ${response.status}`); }
+          return response.text();
+        } )
+        .then( (text) => { theTextArea.value = text; } )
+        .catch( (error) => { console.log = `Could not fetch XSLT from ${HREF}: ${error}`; }
+        );
+    }
+    
+    </script>
+        
+</head>
+
+<body>
+  <div id="nistheadergoeshere">
+    <header class="nist-header" id="nist-header" role="banner">
+      
+      <a href="https://www.nist.gov/"
+        title="National Institute of Standards and Technology"
+        class="nist-header__logo-link" rel="home">
+        <svg aria-hidden="true" class="nist-header__logo-icon" version="1.1"
+          xmlns="http://www.w3.org/2000/svg" width="24" height="32"
+          viewBox="0 0 24 32">
+          <path
+            d="M20.911 5.375l-9.482 9.482 9.482 9.482c0.446 0.446 0.446 1.161 0 1.607l-2.964 2.964c-0.446 0.446-1.161 0.446-1.607 0l-13.25-13.25c-0.446-0.446-0.446-1.161 0-1.607l13.25-13.25c0.446-0.446 1.161-0.446 1.607 0l2.964 2.964c0.446 0.446 0.446 1.161 0 1.607z"
+          />
+        </svg>
+        <svg class="nist-header__logo-image" version="1.1"
+          xmlns="http://www.w3.org/2000/svg" viewBox="-237 385.7 109.7 29.3">
+          <title>National Institute of Standards and Technology</title>
+          <g>
+            <path class="st0"
+              d="M-231,415h-6v-23.1c0,0,0-4.4,4.4-5.8c4-1.3,6.6,1.3,6.6,1.3l19.7,21.3c1,0.6,1.4,0,1.4-0.6v-22h6.1V409
+              c0,1.9-1.6,4.4-4,5.3c-2.4,0.9-4.9,0.9-7.9-1.7l-18.5-20c-0.5-0.5-1.8-0.6-1.8,0.4L-231,415L-231,415z"/>
+            <path class="st0"
+              d="M-195,386.1h6.1v20.7c0,2.2,1.9,2.2,3.6,2.2h26.8c1.1,0,2.4-1.3,2.4-2.7c0-1.4-1.3-2.8-2.5-2.8H-176
+              c-3,0.1-9.2-2.7-9.2-8.5c0-7.1,5.9-8.8,8.6-9h49.4v6.1h-12.3V415h-6v-22.9h-30.2c-2.9-0.2-4.9,4.7-0.2,5.4h18.6
+              c2.8,0,7.4,2.4,7.5,8.4c0,6.1-3.6,9-7.5,9H-185c-4.5,0-6.2-1.1-7.8-2.5c-1.5-1.5-1.7-2.3-2.2-5.3L-195,386.1
+              C-194.9,386.1-195,386.1-195,386.1z"/>
+          </g>
+        </svg>
+      </a>      
+    </header>
+  </div>
+  <details id="sec-notice">
+    <summary>Is this site a preview, demo, mockup or spoof? - <i><b>How you can know</b></i></summary>
+    <p><span>The real site domain ends in <code>nist.gov</code></span>&#xA0;<span>The page address shows <code>https://</code></span></p>
+  </details>
+  <main class="draft">
+    <h1>OSCAL Painter</h1>
+    <p>Try out your own CSS formatting on your own OSCAL.</p>
+    <p>Based on the <a href="index.html">OSCAL Styler</a>, this page lets you load your <a href="https://pages.nist.gov/OSCAL">OSCAL</a> data and style it dynamically with your own CSS. No data is sent to any server.</p>
+    <p>The OSCAL Painter offers a <q>play set</q> or playground for users to explore the OSCAL data model and how it can be handled in a browser via an elaborated HTML surrogate or representation. The HTML for the view is produced using a generic stylesheet, which casts OSCAL data into an isomorphic, equivalent and traceable form of HTML. To see the HTML model, use your web developer tools to examine the result of your OSCAL data in transformation, as it populates the page. In addition to a traceable mapping from HTML tags back to OSCAL, this code is also provided with rudimentary linking behaviors, reflecting the linking semantics of the underlying OSCAL data. By targetting this HTML with CSS, a web designer can provide the view with very sophisticated styling to provide a custom or branded <q>look and feel</q>. If the mapping from OSCAL into an HTML surrogate must be adapted, an application like the <a href="index.html">OSCAL Styler</a> comes into play.</p>
+    <p>Feedback on this demonstration is welcome on the public <a class="external" href="https://github.com/usnistgov/xslt-blender/issues">Github Issues</a> board. Or contribute
+      to community discussions in public <a href="https://pages.nist.gov/OSCAL/contact/">OSCAL</a> channels.</p>
+
+      <details class="boxed" id="loadOSCALpanel">
+        <summary>Load OSCAL <input type="file" id="loadOSCALButton" accept=".xml, .osc, .oscal"  name="loadOSCALButton" title="Load OSCAL"  onchange="loadOSCAL(this.files); this.closest('details').open = true;" 
+        />
+          <button style="float:right" onclick="loadedOSCAL = undefined; clearLoad('loadOSCALButton','OSCALfile');">Clear OSCAL</button></summary>
+        <div id="OSCALfile">
+          <!-- x -->
+        </div>
+      </details>
+  
+
+      <details class="boxed fullwidth"><summary>Load and edit styles
+        <button class="clearButton floatButton" onclick="clearDisplay();">Clear Display</button>
+        <button class="applyButton floatButton" onclick="applyXSLT(); refreshPageCSS();">Apply&#xA0;Styles</button>
+        
+    </summary>
+    <div class="panels">
+      
+    <div class="codePanel">
+      <p>CSS <input type="file" id="loadCSSButton" accept=".css" name="loadCSSButton" title="Load CSS" onchange="dropFileText(this.files,'CSSeditbox');this.parentElement.parentElement.open = true;"
+      />
+      <button class="clearButton floatButton" onclick="clearAll();">Clear All</button>
+      <button class="floatButton" onclick="clearLoad('loadCSSButton','CSSeditbox');">Clear</button></p>
+      <textarea id="CSSeditbox" class="editbox" spellcheck="false" rows="12">body { background-color: white }</textarea>
+      
+    </div>
+    </div>
+    </details>
+    
+    <iframe name="displayFrame" id="displayFrame">Loading frame ...</iframe>
+
+  </div>
+
+    <details class="boxed arrayed">
+      <summary>Who is this for</summary>
+      <ul>
+        <li><a href="https://pages.nist.gov/OSCAL">OSCAL</a> users learning XSLT 1.0 and XPath</li>
+        <li>XSLT and XML practitioners learning <a href="https://pages.nist.gov/OSCAL">OSCAL</a></li>
+        <li>OSCAL developers sketching and testing ideas with real or mock data</li>
+        <li>Any curious students of OSCAL or XSLT</li>
+      </ul>
+      <p>More information on <a class="external" href="https://www.w3.org/TR/xslt-10/">XSLT 1.0</a> may be found on the <a href="https://github.com/usnistgov/xslt-blender/wiki">Project Wiki</a>.</p>
+      
+      <p>This viewer application is maintained on <a class="external" href="https://github.com/usnistgov/xslt-blender/tree/main/sts-viewer">Github, with documentation</a>.</p>
+   </details>
+   <details class="boxed arrayed">
+    <summary>Is this site a demonstration, a service or both?</summary>
+      <p>This application is provided by NIST as an educational demonstration of how a service can be created, not as a fully operational service.</p>
+      <p>No guarantees or warranties are provided by NIST that the demo service will be maintained, updated, upgraded, or always available. While NIST intends to keep the demonstration running (with <a class="external" href="https://github.com/usnistgov/xslt-blender">project source code</a> available), NIST also reserves the right to stop supporting it, or to remove or rework it, without any prior warning.</p>
+      <p>The best way to ensure access to the application over the long term is to replicate it. See the <a class="external" href="https://github.com/usnistgov/xslt-blender/wiki/Maintenance-and-Support">project wiki page on Maintenance and Support</a> for more details on how these projects are designed to be standards-based, accessible, portable, adaptable over time and unhindered by practical impediments to wide deployment, either technical or legal.</p></details>
+  </main>
+  <div class="project-footer">
+    <p><i>OSCAL Styler</i> is an <a  href="https://pages.nist.gov/xslt-blender">XSLT Blender</a> project using XSLT 1.0 capabilities built into your browser, with no external dependencies.</p>
+    <p>Disclaimers apply; no warranty should or can be assumed.</p>
+    <p>See the code and contact the developers in the <a class="external" 
+      href="https://github.com/usnistgov/xslt-blender">project repository</a>.</p>
+  </div>
+  <div id="nistfootergoeshere"><footer class="nist-footer">
+    <div class="nist-footer__inner">
+      <div class="nist-footer__menu" role="navigation">
+        <ul>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/privacy-policy">Site Privacy</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/oism/accessibility">Accessibility</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/privacy">Privacy Program</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/oism/copyrights">Copyrights</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.commerce.gov/vulnerability-disclosure-policy">Vulnerability Disclosure</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/no-fear-act-policy">No Fear Act Policy</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/foia">FOIA</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.nist.gov/environmental-policy-statement">Environmental Policy</a>
+          </li>
+          <li class="nist-footer__menu-item ">
+            <a href="https://www.nist.gov/summary-report-scientific-integrity">Scientific Integrity</a>
+          </li>
+          <li class="nist-footer__menu-item ">
+            <a href="https://www.nist.gov/nist-information-quality-standards">Information Quality Standards</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.commerce.gov/">Commerce.gov</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.science.gov/">Science.gov</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://www.usa.gov/">USA.gov</a>
+          </li>
+          <li class="nist-footer__menu-item">
+            <a href="https://vote.gov/">Vote.gov</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="nist-footer__logo">
+      <a href="https://www.nist.gov/" title="National Institute of Standards and Technology" class="nist-footer__logo-link" rel="home">
+        <img src="https://pages.nist.gov/nist-header-footer/images/nist_logo_brand_white.svg" alt="National Institute of Standards and Technology logo"/>
+      </a>
+    </div>
+  </footer>
+  </div>
+  <script>
+    
+    // initializing by clearing any retained file load
+    clearLoad('loadOSCALButton','OSCALfile');
+    loadedOSCAL = undefined;
+    
+  </script>
+  
+  </body>
+</html>

--- a/oscal-styler/painter.html
+++ b/oscal-styler/painter.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" />
   <style type="text/css" xml:space="preserve" id="pageStyle">
 
-body { background-color: whitesmoke }
+body { background-color: mintcream }
 
 .panels {
   margin-top: 0.6em;
@@ -192,7 +192,8 @@ div.unknown * { margin: 0em}
     <h1>OSCAL Painter</h1>
     <p>Try out your own CSS formatting on your own OSCAL.</p>
     <p>Based on the <a href="index.html">OSCAL Styler</a>, this page lets you load your <a href="https://pages.nist.gov/OSCAL">OSCAL</a> data and style it dynamically with your own CSS. No data is sent to any server.</p>
-    <p>The OSCAL Painter offers a <q>play set</q> or playground for users to explore the OSCAL data model and how it can be handled in a browser via an elaborated HTML surrogate or representation. The HTML for the view is produced using a generic stylesheet, which casts OSCAL data into an isomorphic, equivalent and traceable form of HTML. To see the HTML model, use your web developer tools to examine the result of your OSCAL data in transformation, as it populates the page. In addition to a traceable mapping from HTML tags back to OSCAL, this code is also provided with rudimentary linking behaviors, reflecting the linking semantics of the underlying OSCAL data. By targetting this HTML with CSS, a web designer can provide the view with very sophisticated styling to provide a custom or branded <q>look and feel</q>. If the mapping from OSCAL into an HTML surrogate must be adapted, an application like the <a href="index.html">OSCAL Styler</a> comes into play.</p>
+    <p>The OSCAL Painter offers a <q>play set</q> of tools for users to explore the OSCAL data model and how it can be handled in a browser via an HTML surrogate. This HTML is produced by application of a generalized stylesheet, which casts OSCAL data into an isomorphic, equivalent and traceable form of HTML. To see the HTML model, load OSCAL XML and use your web developer tools to examine the result of this transformation as it populates the page. With CSS styling applied to the HTML, a web designer can provide the view with sophisticated styling, providing a customized or branded <q>look and feel</q>.</p>
+    <a>If the mapping from OSCAL into an HTML surrogate must be adapted, an application like one demonstrated by the <a href="index.html">OSCAL Styler</a> comes into play. <i>Expert tip:</i> <a href="https://www.w3.org/TR/xml-stylesheet/" class="external">CSS can be applied directly to XML</a> even without an intervening HTML conversion.</p>
     <p>Feedback on this demonstration is welcome on the public <a class="external" href="https://github.com/usnistgov/xslt-blender/issues">Github Issues</a> board. Or contribute
       to community discussions in public <a href="https://pages.nist.gov/OSCAL/contact/">OSCAL</a> channels.</p>
 

--- a/oscal-styler/readme.md
+++ b/oscal-styler/readme.md
@@ -11,18 +11,41 @@ Suitable for:
 
 Not suitable for people who "don't want to deal" with source code or processes. If you need black-box, lights-out styling or require exacting production values - this is not the appliance for you.
 
-- [ ] Load an OSCAL XML file from your system (or with a link) - show in "load box" (document title, metadata, element count etc.)
-  - [ ] borrow from STS Viewer
-- [ ] Load an OSCAL XSLT 1.0 into an editing frame with a button (or from your system)
-  - [ ] borrow from HTML Reducer
-  - [ ] It is pregenerated yet also contains specific OSCAL logic
-    - [ ] parameter expansion, uuid manipulation and links
-    - [ ] any element or attribute named '-uuid' gets special handling
-    - [ ] UUIDs are expanded to "uuid_x" etc.
-  - [ ] Hit a button to apply, show results in display
-  - [ ] Another button to clear
-- [ ] Load a CSS into an edit window
+- [x] Load an OSCAL XML file from your system (or with a link) - show in "load box" (document title, metadata, element count etc.)
+  - [x] borrow from STS Viewer
+- [x] Load an OSCAL XSLT 1.0 into an editing frame with a button (or from your system)
+  - [x] borrow from HTML Reducer
+  - [x] Hit a button to apply, show results in display
+  - [x] Another button to clear
+  - [ ] Test and harden against bad inputs
+- [ ] Provide XSLT pre-loads 
+- [x] Load a CSS into an edit window
   - [ ] Hit a button to apply
-  - [ ] Another button to clear
+  - [x] Another button to clear
+  - [ ] Test and defend e.g. against conflicts, overloading, bleeding
 - [ ] Hit a Clear All button to clear everything
 
+Write up approaches
+
+- [ ] 'Least Power' minimal XSLT for styling
+    - parameter expansion, uuid manipulation and links
+    - ids and classes are copied, with local-name() appended to @class
+    - other attributes are mapped to @data-*
+    - except any element or attribute named '-uuid' gets special handling
+    - and UUIDs are expanded to "uuid_x" etc.
+- [ ] Comprehensive mapping into XHTML namespace - schema-driven
+- [ ] Modified identity transformations
+- [ ] Casting into altogether different vocabularies
+- [ ] Doing other things e.g. Obfuscate 'Secret Encoder Ring'
+
+Possible XSLTs
+
+- [ ] OSCAL minimal - maps into 'oscalized' HTML?
+- [ ] OSCAL all auto-generated
+- [ ] OSCAL basic / handmade
+- [ ] Generic identity transformation
+- [ ] OSCAL Obfuscator
+
+not OSCAL
+- Elisa
+- David B

--- a/oscal-styler/readme.md
+++ b/oscal-styler/readme.md
@@ -1,0 +1,28 @@
+# OSCAL XML Styler
+
+XSLT 1.0 Fiddle for OSCAL
+
+Suitable for:
+
+- OSCAL experts learning XSLT 1.0
+- XSLT/XML practitioners learning OSCAL
+- Any students of XSLT or OSCAL
+- OSCAL developers sketching and testing ideas with real or test data
+
+Not suitable for people who "don't want to deal" with source code or processes. If you need black-box, lights-out styling or require exacting production values - this is not the appliance for you.
+
+- [ ] Load an OSCAL XML file from your system (or with a link) - show in "load box" (document title, metadata, element count etc.)
+  - [ ] borrow from STS Viewer
+- [ ] Load an OSCAL XSLT 1.0 into an editing frame with a button (or from your system)
+  - [ ] borrow from HTML Reducer
+  - [ ] It is pregenerated yet also contains specific OSCAL logic
+    - [ ] parameter expansion, uuid manipulation and links
+    - [ ] any element or attribute named '-uuid' gets special handling
+    - [ ] UUIDs are expanded to "uuid_x" etc.
+  - [ ] Hit a button to apply, show results in display
+  - [ ] Another button to clear
+- [ ] Load a CSS into an edit window
+  - [ ] Hit a button to apply
+  - [ ] Another button to clear
+- [ ] Hit a Clear All button to clear everything
+

--- a/oscal-styler/readme.md
+++ b/oscal-styler/readme.md
@@ -24,10 +24,12 @@ Not suitable for people who "don't want to deal" with source code or processes. 
   - [x] Another button to clear
   - [ ] Test and defend e.g. against conflicts, overloading, bleeding
 - [ ] Hit a Clear All button to clear everything
+- [ ] Deploy an OSCAL Painter application to do CSS only - decorate your OSCAL in the browser 
 
 Write up approaches
 
 - [ ] 'Least Power' minimal XSLT for styling
+    - OSCAL is copied through and sometimes *wrapped* (not mapped over to) HTML 
     - parameter expansion, uuid manipulation and links
     - ids and classes are copied, with local-name() appended to @class
     - other attributes are mapped to @data-*

--- a/oscal-styler/show-loaded-xml.xsl
+++ b/oscal-styler/show-loaded-xml.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
     xmlns="http://www.w3.org/1999/xhtml" xmlns:oscal="http://csrc.nist.gov/ns/oscal/1.0">
     
+    
     <xsl:template match="/*">
         <xsl:variable name="class">
             <xsl:choose>
@@ -9,25 +10,30 @@
                 <xsl:otherwise>unknown</xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
-        <h4>XML document loaded: <tt><xsl:value-of select="name()"/></tt></h4>
-        <div class="{ $class }">
-            <xsl:for-each select="/*/oscal:metadata/oscal:title">
-                <h5><xsl:apply-templates/></h5>
-            </xsl:for-each>
-            <xsl:if test="$class='unknown'"><h5>not an OSCAL document</h5></xsl:if>
-            <p>
-                <xsl:value-of select="count(//*)"/>
-                <xsl:choose>
-                    <xsl:when test="count(//*) &gt; 1"> elements; </xsl:when>
-                    <xsl:otherwise> element; </xsl:otherwise>
-                </xsl:choose>
-                <xsl:value-of select="count(//@*)"/>
-                <xsl:choose>
-                    <xsl:when test="count(//@*) &gt; 1"> attributes</xsl:when>
-                    <xsl:otherwise> attribute</xsl:otherwise>
-                </xsl:choose>
-            </p>
-            
+        <div>
+            <h4>XML document loaded: <tt><xsl:value-of select="name()"/></tt></h4>
+            <div class="{ $class }">
+                <xsl:for-each select="/*/oscal:metadata/oscal:title">
+                    <h5>
+                        <xsl:apply-templates/>
+                    </h5>
+                </xsl:for-each>
+                <xsl:if test="$class = 'unknown'">
+                    <h5>not an OSCAL document</h5>
+                </xsl:if>
+                <p>
+                    <xsl:value-of select="count(//*)"/>
+                    <xsl:choose>
+                        <xsl:when test="count(//*) &gt; 1"> elements; </xsl:when>
+                        <xsl:otherwise> element; </xsl:otherwise>
+                    </xsl:choose>
+                    <xsl:value-of select="count(//@*)"/>
+                    <xsl:choose>
+                        <xsl:when test="count(//@*) &gt; 1"> attributes</xsl:when>
+                        <xsl:otherwise> attribute</xsl:otherwise>
+                    </xsl:choose>
+                </p>
+            </div>
         </div>
     </xsl:template>
     

--- a/oscal-styler/show-loaded-xml.xsl
+++ b/oscal-styler/show-loaded-xml.xsl
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns="http://www.w3.org/1999/xhtml" xmlns:oscal="http://csrc.nist.gov/ns/oscal/1.0">
+    
+    <xsl:template match="/*">
+        <xsl:variable name="class">
+            <xsl:choose>
+                <xsl:when test="self::oscal:*">oscal</xsl:when>
+                <xsl:otherwise>unknown</xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <h4>XML document loaded: <tt><xsl:value-of select="name()"/></tt></h4>
+        <div class="{ $class }">
+            <xsl:for-each select="/*/oscal:metadata/oscal:title">
+                <h5><xsl:apply-templates/></h5>
+            </xsl:for-each>
+            <xsl:if test="$class='unknown'"><h5>not an OSCAL document</h5></xsl:if>
+            <p>
+                <xsl:value-of select="count(//*)"/>
+                <xsl:choose>
+                    <xsl:when test="count(//*) &gt; 1"> elements; </xsl:when>
+                    <xsl:otherwise> element; </xsl:otherwise>
+                </xsl:choose>
+                <xsl:value-of select="count(//@*)"/>
+                <xsl:choose>
+                    <xsl:when test="count(//@*) &gt; 1"> attributes</xsl:when>
+                    <xsl:otherwise> attribute</xsl:otherwise>
+                </xsl:choose>
+            </p>
+            
+        </div>
+    </xsl:template>
+    
+    
+</xsl:stylesheet>

--- a/sts-viewer/checker.html
+++ b/sts-viewer/checker.html
@@ -186,7 +186,7 @@
     <summary>Is this site a preview, demo, mockup or spoof? - <i><b>How you can know</b></i></summary>
     <p><span>The real site domain ends in <code>nist.gov</code></span>&#xA0;<span>The page address shows <code>https://</code></span></p>
   </details>
-  <main class="draft">
+  <main>
     <h1>STS Checker</h1>
     <p>Load your STS XML document for an analytic summary report of findings and potential issues, produced in your browser. Subject to its limitations, the application will also work on other JATS-based formats such as JATS and BITS.</p>
     <p>A <a href="index.html">Generic STS Preview</a> utility is also available on this site.</p>


### PR DESCRIPTION
The **OSCAL Styler** is an XSLT 1.0 Fiddle application set up for OSCAL.

It should work with any XML and XSLT 1.0, however, not only OSCAL.

The user can provide an XSLT, and additionally CSS code, and edit both on the page.

Plus, it has a companion (little) application, the OSCAL Painter - same, except with a pre-coded XSLT to save that step, so only CSS is a factor.

Along with the new project are a couple of minor tweaks and updates elsewhere.

### Completeness checklist:

Within the scope of work,

- [x] All readme files and documentation resources are current
- [x] Initial comments look reasonable
- [x] Everything touched has been checked for parsing as appropriate (wf/valid)
- [x] Everything is tested in multiple browsers (minimally: FF and Chrome)
- [x] The top-level directory is current or planned for updating
- [x] As appropriate, outbound external links are marked as `class="external"` (drives popup)

### PR/merge guidelines:

Despite its being a bit cumbersome with respect to commit history, we are using git in a 'safe' mode to avoid potential issues aligning the publication branch, `nist-pages`.

- Merging into `main`, squashing commits in a PR is okay (recommended)
- Don't merge anything into `nist-pages` except `main`, and *never squash* commits in those PRs
- The `main` branch also keeps up with `nist-pages` (merge commits), so after committing to `nist-pages`, pulling back is necessary
