### PR TITLE
Adjustments improving handling of JSON Reader

### DIFF
--- a/json-mixer/json-reader.html
+++ b/json-mixer/json-reader.html
@@ -22,7 +22,7 @@
     #JSON-display { max-width: 48em }
     
     #JSON-display div:before { content: attr(title) " "; font-weight: bold }
-    #JSON-display div.string:before { content: attr(title) " " open-quote; font-weight: bold }
+    #JSON-display div.string:before { font-weight: bold; content: attr(title) " " open-quote }
     #JSON-display div.string:after  { content: close-quote; font-weight: bold }
     
   </style>
@@ -58,8 +58,10 @@ function tagAnyProperty(obj, key, top) {
     // making @key only for (named) object properties, not (enumerated) array members
     let xml = `<${tagValue(obj)}${top ? xpathns : ""}${isNaN(key) ? ` key='${key}'` : ""}>`;
 
+    // on strings, we escape open delimiters into markup (entity notation)
+    if ((typeof obj) === "string") { xml += obj.replaceAll('&','&amp;').replaceAll('<','&lt;') }
     // if we know the object type as a scalar, we can write the value
-    if (scalarTypes.includes(typeof obj)) { xml += obj }
+    else if (scalarTypes.includes(typeof obj)) { xml += obj }
     // or for objects and arrays, we process contents recursively
     else if (typeof obj === "object") {
         for (const prop in obj) { xml += tagAnyProperty(obj[prop], prop, false); }
@@ -134,8 +136,7 @@ async function filterAndShowXML(xmlLiteral, targetID) {
     <p>This demonstration paints what it sees back to the screen.</p>
   <input type="file" id="loadJSON" name="loadJSON" title="Load JSON" onchange="filterAndShowJSONFiles(this.files)" />
     <p>Load your JSON: the application does its best to parse and read it.</p>
-    <p>Parser errors will be presented in an alert. The built-in JSON parser is very particular about superfluous trailing commas, so avoid them.</p>
-      <p>TODO in this project: provide an editing window for the JSON; provide a Clear button.</p>
+    <p>Parser errors will be presented in an alert. The built-in JSON parser rejects superfluous trailing commas, so avoid them. If your JSON produces errors here but works elsewhere, please consider filing a <a class="external" href="https://github.com/usnistgov/xslt-blender/issues">bug report</a> with a similar example for testing.</p>
   <div id="JSON-display">
     <!-- -->
   </div>


### PR DESCRIPTION
Repairs issues in JSON Reader.

Addresses #62 and also #3. From here we can start with fresh 'failure' examples.

### Completeness checklist:

Within the scope of work,

- [x] All readme files and documentation resources are current
- [x] Initial comments look reasonable
- [x] Everything touched has been checked for parsing as appropriate (wf/valid)
- [x] Everything is tested in multiple browsers (minimally: FF and Chrome)
- [x] The top-level directory is current or planned for updating
- [x] As appropriate, outbound external links are marked as `class="external"` (drives popup)
