### PR TITLE
Adding XProc 3.0 Plotter application

### DIFF
--- a/directory.xml
+++ b/directory.xml
@@ -5,7 +5,8 @@
       <name>XProc Plotter</name>
       <line>XProc 3.0 simple display</line>
       <description>
-         <p>This rendition of an <a href="https://xproc.org">XProc 3.0 pipeline</a> may be somewhat easier to read than raw source code, and it breaks XProc step declarations into their parts - imports, prologue, step declarations and steps (subpipelines). So, at least useful as an illustration.</p>
+         <p>This rendition of an <a href="https://xproc.org">XProc 3.0 pipeline</a>  breaks XProc step declarations into their parts - imports, prologue, step declarations and subpipelines (step sequences).</p>
+         <p>HTML results could be enhanced with some smart CSS and interactivity - let us know what ideas come up (flexboxes?). The XSLT could also be integrated into other pipelines.</p>
       </description>
    </project>
    <project entry="oscal-styler">

--- a/directory.xml
+++ b/directory.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="site/projects-page.xsl"?>
 <projects>
-    <project entry="oscal-styler">
+   <project entry="xproc-visualizer/xproc3-plot.html">
+      <name>XProc Plotter</name>
+      <line>XProc 3.0 simple display</line>
+      <description>
+         <p>This rendition of an <a href="https://xproc.org">XProc 3.0 pipeline</a> may be somewhat easier to read than raw source code, and it breaks XProc step declarations into their parts - imports, prologue, step declarations and steps (subpipelines). So, at least useful as an illustration.</p>
+      </description>
+   </project>
+   <project entry="oscal-styler">
         <name>OSCAL Styler</name>
         <line>XSLT like it's 1999</line>
         <description>

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
           <li><a href="oscal-styler/">OSCAL Styler</a> and <a href="oscal-styler/painter.html">Painter</a></li>
           <li><a href="sts-viewer/">STS Viewer</a> and <a href="sts-viewer/checker.html">Checker</a></li>
           <li><a href="html-reducer/">HTML Reducer</a></li>
-          <li><a href="xproc-visualizer/">XProc Visualizer</a></li>
+          <li><a href="xproc-visualizer/xproc3-plot.html">XProc 3.0 Plotter</a></li>
         </ul>
         <details class="boxed">
           <summary style="font-style: italic">About the currently active projects</summary>

--- a/xproc-visualizer/viewer.js
+++ b/xproc-visualizer/viewer.js
@@ -15,3 +15,15 @@ async function filterAndViewXMLFiles(fileSet, whereToView) {
    while ( clearing.firstChild && clearing.removeChild(clearing.firstChild) );
      document.getElementById("loadSTS").files = noFiles;
    }
+
+ const highLight = (plugID) => {
+   document.getElementById(plugID).classList.add("LIT-UP");
+    
+ }
+ 
+ const unHighLight = (plugID) => {
+   document.getElementById(plugID).classList.remove("LIT-UP");
+    
+ }
+ 
+ 

--- a/xproc-visualizer/viewer.js
+++ b/xproc-visualizer/viewer.js
@@ -1,0 +1,17 @@
+
+async function filterAndViewXMLFiles(fileSet, whereToView) {
+    for (const eachFile of fileSet) {
+      const maybeSTSXML = await fileXMLContent(eachFile);
+      if (maybeSTSXML) {
+        viewAndShowXML(maybeSTSXML, whereToView);
+      }
+    }
+  }
+  
+ const clearView = (whereToClear) => {
+   const clearing = document.getElementById(whereToClear);
+   let emptyList = new DataTransfer();
+   let noFiles = emptyList.files;
+   while ( clearing.firstChild && clearing.removeChild(clearing.firstChild) );
+     document.getElementById("loadSTS").files = noFiles;
+   }

--- a/xproc-visualizer/xproc-plot-html.xsl
+++ b/xproc-visualizer/xproc-plot-html.xsl
@@ -149,7 +149,28 @@
    
    <xsl:template match="*">
       <section id="{ generate-id() }">
-         <xsl:for-each select="key('port-by-namekey',@pipe)">
+         <xsl:variable name="pipe-connector">
+            <xsl:choose>
+               <xsl:when test="substring-after(@pipe,'@') = /*/@name">
+                  <xsl:value-of select="@pipe"/>
+               </xsl:when>
+               <xsl:when test="@pipe">
+                  <xsl:text>@</xsl:text>
+                  <xsl:value-of select="substring-after(@pipe,'@')"/>
+               </xsl:when>
+               <xsl:when test="p:pipe[@step = /*/@name]">
+                  <xsl:value-of select="p:pipe/@pipe"/>
+                  <xsl:text>@</xsl:text>
+                  <xsl:value-of select="p:pipe/@step"/>
+               </xsl:when>
+               <xsl:when test="p:pipe">
+                  <xsl:text>@</xsl:text>
+                  <xsl:value-of select="p:pipe/@step"/>
+               </xsl:when>
+               <xsl:otherwise>-</xsl:otherwise>
+            </xsl:choose>
+         </xsl:variable>
+         <xsl:for-each select="key('port-by-namekey',$pipe-connector)">
             <xsl:attribute name="onmouseenter">
                <xsl:text>highLight('</xsl:text>
                <xsl:value-of select="generate-id()"/>
@@ -167,6 +188,8 @@
    </xsl:template>
    
    <xsl:key name="port-by-namekey" match="*[@port]" use="concat(@port, '@', parent::*/@name)"/>
+   
+   <xsl:key name="port-by-namekey" match="*[@name]" use="concat('@', @name)"/>
    
    <xsl:template match="*[count(@*[not((name() = 'name') or (name() = 'port')) or (name() = 'pipe')]) > 0]" mode="label-step">
          <p class="el { local-name() }">

--- a/xproc-visualizer/xproc-plot-html.xsl
+++ b/xproc-visualizer/xproc-plot-html.xsl
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+   xmlns:p="http://www.w3.org/ns/xproc" xmlns="http://www.w3.org/1999/xhtml"
+   exclude-result-prefixes="p"
+   version="1.0">
+
+   <!--
+   Punchlist
+   
+   ToC/directory
+   CSS
+   - grid?
+   -->
+
+
+   <xsl:variable name="page-title">
+      <xsl:value-of select="name(/*)"/>
+      <xsl:text> </xsl:text>
+      <xsl:value-of select="/*/@type"/>
+   </xsl:variable>
+
+   <xsl:template match="/*">
+      <html>
+         <head>
+            <title>
+               <xsl:value-of select="$page-title"/>
+            </title>
+            <xsl:call-template name="make-style"/>
+            <xsl:call-template name="make-script"/>
+         </head>
+         <body>
+            <main>
+               <xsl:call-template name="lede"/>
+               <!-- p:documentation is a complication in producing a map of an XProc
+               
+               -->
+
+               <xsl:call-template name="plot-pipeline"/>
+            </main>
+         </body>
+      </html>
+   </xsl:template>
+
+
+
+<!-- modes: import, prologue, step-decls, subpipeline filter for the respective groups
+      then reverting to unnamed mode -->
+   
+   <xsl:template mode="pull-imports" match="*"/>
+   <xsl:template mode="pull-imports" match="p:import | p:import-functions">
+      <xsl:apply-templates select="."/>
+   </xsl:template>
+   <xsl:template mode="pull-imports" match="p:documentation[following-sibling::p:import | following-sibling::p:import-functions]">
+      <xsl:apply-templates select="."/>
+   </xsl:template>
+
+   <xsl:template mode="pull-prologue" match="*"/>
+   <xsl:template mode="pull-prologue" match="p:input | p:option | p:output | p:with-input | p:with-option">
+      <xsl:apply-templates select="."/>
+   </xsl:template>
+   <xsl:template mode="pull-prologue"  match="p:documentation[following-sibling::p:import | following-sibling::p:import-functions]"/>
+   <xsl:template mode="pull-prologue" match="p:documentation[following-sibling::p:input | following-sibling::p:option | following-sibling::p:output | following-sibling::p:with-input | following-sibling::p:with-option]">
+      <xsl:apply-templates select="."/>
+   </xsl:template>
+   
+   <xsl:template mode="pull-step-decls" match="p:import | p:import-functions | p:input | p:option | p:output | p:with-input | p:with-option"/>
+   <xsl:template mode="pull-step-decls" match="p:documentation[following-sibling::p:import | following-sibling::p:import-functions]"/>
+   <xsl:template mode="pull-step-decls" match="p:documentation[following-sibling::p:import | following-sibling::p:import-functions | following-sibling::p:input | following-sibling::p:option | following-sibling::p:output | following-sibling::p:with-input | following-sibling::p:with-option]"/>
+   <xsl:template mode="pull-step-decls" priority="2" match="p:declare-step | p:documentation[following-sibling::p:declare-step]">
+      <xsl:apply-templates select="."/>
+   </xsl:template>
+   <xsl:template mode="pull-step-decls" match="*"/>
+   
+   <xsl:template mode="pull-subpipeline" match="p:import | p:import-functions | p:input | p:option | p:output | p:with-input | p:with-option | p:declare-step"/>
+   <xsl:template mode="pull-subpipeline" match="p:documentation[following-sibling::p:import | following-sibling::p:import-functions]"/>
+   <xsl:template mode="pull-subpipeline" match="p:documentation[following-sibling::p:import | following-sibling::p:import-functions | following-sibling::p:input | following-sibling::p:option | following-sibling::p:output | following-sibling::p:with-input | following-sibling::p:with-option | following-sibling::p:declare-step]"/>
+   <xsl:template mode="pull-subpipeline" match="p:declare-step | p:documentation[following-sibling::p:declare-step]"/>
+   <xsl:template mode="pull-subpipeline" match="*">
+      <xsl:apply-templates select="."/>
+   </xsl:template>
+   
+   <xsl:template match="p:declare-step">
+      <details class="declaration" id="{generate-id()}">
+         <summary><span class="el"><xsl:call-template name="step-label"/></span></summary>
+         <xsl:call-template name="plot-pipeline"/>
+      </details>
+   </xsl:template>
+   
+   <xsl:template name="plot-pipeline" match="p:library">
+      <xsl:variable name="imports">
+         <xsl:apply-templates mode="pull-imports"/>
+      </xsl:variable>
+      <xsl:variable name="prologue">
+         <xsl:apply-templates mode="pull-prologue"/>
+      </xsl:variable>
+      <xsl:variable name="step-declarations">
+         <xsl:apply-templates mode="pull-step-decls"/>
+      </xsl:variable>
+      <xsl:variable name="steps">
+         <xsl:apply-templates mode="pull-subpipeline"/>
+      </xsl:variable>
+      <!-- brute force testing the results to see which divs to produce -->
+      <xsl:if test="normalize-space($imports)">
+         <div class="imports">
+            <xsl:copy-of select="$imports"/>
+         </div>
+      </xsl:if>
+      <xsl:if test="normalize-space($prologue)">
+         <div class="prologue">
+            <xsl:copy-of select="$prologue"/>
+         </div>
+      </xsl:if>
+      <xsl:if test="normalize-space($step-declarations)">
+         <div class="declarations">
+            <xsl:copy-of select="$step-declarations"/>
+         </div>
+      </xsl:if>
+      <xsl:if test="normalize-space($steps)">
+         <div class="subpipeline">
+            <xsl:copy-of select="$steps"/>
+         </div>
+      </xsl:if>
+   </xsl:template>
+
+   <xsl:template match="p:for-each | p:try | p:if | p:choose | p:viewport | p:group | p:catch | p:when | p:otherwise">
+      <details class="{ local-name() }" id="{generate-id()}">
+         <summary><span class="el"><xsl:call-template name="step-label"/></span></summary>
+         <xsl:call-template name="plot-pipeline"/>
+      </details>
+   </xsl:template>
+   
+   <xsl:template match="p:documentation[text()[normalize-space()]]" priority="10">
+      <p class="documentation">
+         <xsl:apply-templates mode="in-docs"/>
+      </p>
+   </xsl:template>
+   
+   <xsl:template match="p:documentation">
+         <xsl:apply-templates mode="in-docs"/>
+   </xsl:template>
+   
+   <!-- we assume elements in docs cast to HTML - mode can be amended -->
+   <xsl:template mode="in-docs" match="*">
+       <xsl:element name="{local-name()}" namespace="http://www.w3.org/1999/xhtml">
+          <xsl:copy-of select="@*"/>
+          <xsl:apply-templates/>
+       </xsl:element>
+   </xsl:template>
+   
+   <xsl:template match="*">
+      <section id="{ generate-id() }">
+         <xsl:for-each select="key('port-by-namekey',@pipe)">
+            <xsl:attribute name="onmouseenter">
+               <xsl:text>highLight('</xsl:text>
+               <xsl:value-of select="generate-id()"/>
+               <xsl:text>')</xsl:text>
+            </xsl:attribute>
+            <xsl:attribute name="onmouseleave">
+               <xsl:text>unHighLight('</xsl:text>
+               <xsl:value-of select="generate-id()"/>
+               <xsl:text>')</xsl:text>
+            </xsl:attribute>
+         </xsl:for-each>
+         
+         <xsl:apply-templates select="." mode="label-step"/>
+      </section>
+   </xsl:template>
+   
+   <xsl:key name="port-by-namekey" match="*[@port]" use="concat(@port, '@', parent::*/@name)"/>
+   
+   <xsl:template match="*[count(@*[not((name() = 'name') or (name() = 'port')) or (name() = 'pipe')]) > 0]" mode="label-step">
+         <p class="el { local-name() }">
+            <xsl:value-of select="name()"/>
+            <xsl:for-each select="@name | @port | @pipe">
+               <xsl:call-template name="tag-attribute"/>
+            </xsl:for-each>
+            <ul>
+               <xsl:for-each select="@*[not((name() = 'name') or (name() = 'port') or (name() = 'pipe'))]">
+                  <li>
+                     <xsl:call-template name="tag-attribute"/>
+                  </li>
+               </xsl:for-each>
+            </ul>
+         </p>
+         <xsl:apply-templates/>
+   </xsl:template>
+   
+   <xsl:template name="tag-attribute">
+      <xsl:text> </xsl:text>
+      <xsl:value-of select="name()"/>
+      <xsl:text>="</xsl:text>
+      <code class="v">
+         <xsl:value-of select="."/>
+      </code>
+      <xsl:text>"</xsl:text>
+   </xsl:template>
+   
+   <xsl:template match="*" mode="label-step" name="label-step">
+         <p class="el { local-name() }">
+            <xsl:call-template name="step-label"/>
+         </p>
+         <xsl:apply-templates/>
+   </xsl:template>
+   
+   <xsl:template name="step-label">
+      <xsl:value-of select="name()"/>
+      <xsl:for-each select="@*">
+         <xsl:call-template name="tag-attribute"/>
+        </xsl:for-each>
+   </xsl:template>
+   
+   
+
+   <xsl:template name="make-style">
+      <style xml:space="preserve">
+#XProcPlot {
+
+body { font-family: sans-serif }
+.el { width: fit-content; padding: 0.2em; margin-right: 1em; border: thin outset black; border-bottom: medium solid black; background-color: lightsteelblue }
+span.el { display: inline }
+main div { padding: 0.2em; outline: thin dotted black; margin-top: 0.4em }
+main details { padding: 0.6em; outline: thin dotted black; margin-top: 0.8em }
+main details.declaration { background-color: lavenderblush }
+main div.prologue { background-color: lemonchiffon }
+main div.subpipeline { background-color: whitesmoke }
+main div:before { float: right; font-size:70%; font-weight: bold; background-color: black; color: white; padding: 0.4em }
+main div:before { content: attr(class) }
+.prologue .el, .el.with-input, .el.with-option { background-color: pink }
+.el.import, .el.import-functions { background-color: midnightblue; color: white }
+.el.variable  { background-color: lavender }
+code.v { font-family: monospace; display: inline-block; padding: 0.2em }
+code.v:hover { background-color: lightyellow; outline: thin dotted darkred }
+section section { margin-left: 1em; padding-left: 1em; border-left: thin solid black }
+ul { margin: 0em }
+li { list-style-type: none }
+
+section { width: fit-content;
+  margin: 0.3em;
+  padding: 0.2em }
+section:hover { outline: medium dotted steelblue;
+  background-color: lightsteelblue }
+.LIT-UP { outline: medium dotted darkred;
+  background-color: thistle }
+
+}
+         </style>
+   </xsl:template>
+
+   <xsl:template name="make-script"/>
+
+   <xsl:template name="lede">
+      <h1>
+         <xsl:value-of select="$page-title"/>
+      </h1>
+   </xsl:template>
+   
+</xsl:stylesheet>

--- a/xproc-visualizer/xproc3-plot.html
+++ b/xproc-visualizer/xproc3-plot.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+
+<head>
+  <title>XProc 3.0 Plot</title>
+  <meta charset="utf-8" />
+  <style type="text/css">
+
+  </style>
+  <link rel="stylesheet" href="../site/nist-boilerplate.css" type="text/css" />
+  <link rel="stylesheet" href="../site/nist-combined.css"/>
+  <!--<link rel="stylesheet" href="sts-html.css" type="text/css" />-->
+  <style type="text/css">
+     
+.project-footer { margin-top: 1em }
+
+p { margin: 0.6em 0em; max-width: 54em; line-height: 1.62 }
+
+
+.project-footer p { max-width: inherit}
+
+h1, h2, h3, h4, h5, h6, summary, .reflect, *:before { font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; }
+
+aside > *:last-child { margin-bottom: 0em }
+
+  </style>
+   
+  <script type="text/javascript" src="https://code.jquery.com/jquery-3.6.1.min.js"></script>
+  <!-- Remove the nist-header-footer.js script to drop the NIST header and footer  -->
+  <script src="https://pages.nist.gov/nist-header-footer/js/nist-header-footer.js" type="text/javascript" defer="defer"></script>
+  
+  <!-- Google analytics https://github.com/usnistgov/pages-root/wiki/Adding-NIST-required-branding-and-features-to-your-site   -->
+  
+  <!--<script async="async" type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NIST%26subagency=github%26pua=UA-66610693-1%26yt=true%26exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c">
+</script>-->
+   
+  <script type="module">
+      import { fileXMLContent, spliceIntoPage, xslt1ResultDocument, xsltEngineForHREF } from "../lib/xslt-blender.js";
+
+      // todo: replace with something a little less cumbersome?
+      window.xslt1ResultDocument = xslt1ResultDocument;
+      window.fileXMLContent = fileXMLContent;
+      window.spliceIntoPage = spliceIntoPage;
+      // window.parseAndTransformXMLLiteral = parseAndTransformXMLLiteral;
+      window.xsltEngineForHREF = xsltEngineForHREF;
+
+  </script>
+   
+  <script type="text/javascript" src="viewer.js"> </script>
+  <script type="text/javascript">
+
+ 
+    async function viewAndShowXML(xmlDocument, targetID) {
+      // move this up outside the function call for memoability?
+      const viewerXSLTEngine = await xsltEngineForHREF('xproc-plot-html.xsl');
+      const resultDocument = xslt1ResultDocument(xmlDocument, viewerXSLTEngine); // a promise
+      return spliceIntoPage(targetID, resultDocument, true);
+    }
+  </script>
+  
+  <script type="text/javascript" src="https://pages.nist.gov/leaveNotice/js/jquery.leaveNotice-nist.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="https://pages.nist.gov/leaveNotice/css/jquery.leaveNotice.css" />
+  <!-- load MathJax -->
+  <!-- https://docs.mathjax.org/en/latest/web/configuration.html#configuring-and-loading-in-one-script -->
+  <!--<script src="load-mathjax.js" async> <!-\- and close -\-> </script>--> 
+</head>
+
+<body>
+  <!-- NIST header goes here -->
+  <div style="display: none" class="teaser">A preview in your browser of your NISO STS data</div>
+  <details id="sec-notice">
+    <summary>Is <a href="..">this site</a> a preview, mockup or spoof? - <i><b>How you can know</b></i></summary>
+    <p><span>The real site domain ends in <code>nist.gov</code></span>&#xA0;<span>The page address shows <code>https://</code></span></p>
+  </details>
+  <main class="draft">
+    <h1>XProc 3.0 Plotter</h1>
+    <p>A simple preview of an XProc 3.0 pipeline step declaration or library.</p>
+    <p>Load your XProc 3.0 below: the application does its best to process and display it. All processing is in your browser.</p>
+    <p>Feedback on this demonstration is welcome on the public <a class="external" href="https://github.com/usnistgov/xslt-blender/issues">Github Issues</a> board.</p>
+     <p>Users of XProc 3.0 may also be interesting in a related project, <a class="external" href="">OSCAL XProc 3.0</a>,.</p>
+    <input type="file" id="loadSTS" name="loadSTS" title="Load STS XML"
+       onchange="filterAndViewXMLFiles(this.files,'XProcPlot')" />
+     <button style="float:right" onclick="clearView('XProcPlot')">Clear page</button>
+    <div id="XProcPlot"><!-- --></div>
+    <details class="boxed arrayed">
+      <summary>About XProc 3.0</summary>
+       <p><a class="external" href="https://xproc.org">XProc 3.0</a> is the latest generation of W3C XProc XML pipelining technology.</p>
+      <p>This viewer application is maintained on <a class="external" href="https://github.com/usnistgov/xslt-blender/tree/main/sts-viewer">Github, with documentation</a>.</p>
+   </details>
+    <details class="boxed arrayed">
+    <summary>Is this site a demonstration, a service or both?</summary>
+      <p>This application is provided by NIST as an educational demonstration of how a service can be created, not as a fully operational service.</p>
+      <p>No guarantees or warranties are provided by NIST that the demo service will be maintained, updated, upgraded, or always available. While NIST intends to keep the demonstration running (with <a class="external" href="https://github.com/usnistgov/xslt-blender">project source code</a> available), NIST also reserves the right to stop supporting it, or to remove or rework it, without any prior warning.</p>
+      <p>The best way to ensure access to the application over the long term is to replicate it. See the <a class="external" href="https://github.com/usnistgov/xslt-blender/wiki/Maintenance-and-Support">project wiki page on Maintenance and Support</a> for more details on how these projects are designed to be standards-based, accessible, portable, adaptable over time and unhindered by practical impediments to wide deployment, either technical or legal.</p></details>
+  </main>
+  <div class="project-footer">
+     <p><i>XProc 3.0 Plotter</i> and <a href="index.html">XProc Visualizer</a> are <a  href="https://pages.nist.gov/xslt-blender">XSLT Blender</a> projects using XSLT 1.0 capabilities built into your browser, with no external dependencies.</p>
+    <p>Disclaimers apply; no warranty should or can be assumed.</p>
+    <p>See the code and contact the developers in the <a class="external" 
+      href="https://github.com/usnistgov/xslt-blender">project repository</a>.</p>
+  </div>
+  <!-- NIST footer goes here -->
+  <script src="../site/nist-bounce.js"> </script>
+  
+  </body>
+</html>


### PR DESCRIPTION
Adds new page to XProc visualizer project - it produces a simple 'plot' of an XProc 3.0 library or step declaration (file).

As is it might be useful, especially to learners. Also, plenty of room for enhancement especially given CSS/Javascript skills.

### Completeness checklist:

Within the scope of work,

- [x] All readme files and documentation resources are current
- [x] Initial comments look reasonable
- [x] Everything touched has been checked for parsing as appropriate (wf/valid)
- [x] Everything is tested in multiple browsers (minimally: FF and Chrome)
- [x] The top-level directory is current or planned for updating
- [x] As appropriate, outbound external links are marked as `class="external"` (drives popup)

### PR/merge guidelines:

Despite its being a bit cumbersome with respect to commit history, we are using git in a 'safe' mode to avoid potential issues aligning the publication branch, `nist-pages`.

- Merging into `main`, squashing commits in a PR is okay (recommended)
- Don't merge anything into `nist-pages` except `main`, and *never squash* commits in those PRs
- The `main` branch also keeps up with `nist-pages` (merge commits), so after committing to `nist-pages`, pulling back is necessary
